### PR TITLE
Add tests for translateRelevance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -887,7 +887,8 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "supports-color": {
           "version": "7.1.0",
@@ -4115,7 +4116,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4158,7 +4160,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -4169,7 +4172,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4286,7 +4290,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4298,6 +4303,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4320,12 +4326,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4344,6 +4352,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -4434,7 +4443,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4446,6 +4456,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4523,7 +4534,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4559,6 +4571,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4578,6 +4591,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4621,12 +4635,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5010,6 +5026,7 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -5019,7 +5036,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8546,6 +8564,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "callsites": "^3.0.0"
       }

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -1,5 +1,5 @@
 const { normalizeVariantRecord } = require('../src/civic/variant');
-
+const { translateRelevance } = require('../src/civic');
 
 describe('normalizeVariantRecord', () => {
     test('exon mutation', () => {
@@ -614,4 +614,32 @@ describe('normalizeVariantRecord', () => {
             }]);
         });
     });
+});
+
+describe('translateRelevance', () => {
+    test.each([
+        ['Predictive', 'Supports', 'Sensitivity', 'sensitivity'],
+        ['Predictive', 'Supports', 'Adverse Response', 'adverse response'],
+        ['Predictive', 'Supports', 'Reduced Sensitivity', 'reduced sensitivity'],
+        ['Predictive', 'Supports', 'Resistance', 'resistance'],
+        ['Predictive', 'Supports', 'Sensitivity/Response', 'sensitivity'],
+        ['Diagnostic', 'Supports', 'Positive', 'favours diagnosis'],
+        ['Diagnostic', 'Supports', 'Negative', 'opposes diagnosis'],
+        ['Prognostic', 'Supports', 'Negative', 'unfavourable prognosis'],
+        ['Prognostic', 'Supports', 'Poor Outcome', 'unfavourable prognosis'],
+        ['Prognostic', 'Supports', 'Positive', 'favourable prognosis'],
+        ['Prognostic', 'Supports', 'Better Outcome', 'favourable prognosis'],
+        ['Predisposing', 'Supports', 'Positive', 'predisposing'],
+        ['Predisposing', 'Supports', null, 'predisposing'],
+        ['Predisposing', 'Supports', 'null', 'predisposing'],
+        ['Predisposing', 'Supports', 'Pathogenic', 'pathogenic'],
+        ['Predisposing', 'Supports', 'Likely Pathogenic', 'likely pathogenic'],
+        ['Functional', 'Supports', 'Gain of Function', 'gain of function'],
+        // ['Predictive', 'Does not Support', 'Sensitivity', 'no response'],
+        // ['Predictive', 'Does not Support', 'Sensitivity/Response', 'no response'],
+    ])(
+        '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
+            expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);
+        },
+    );
 });


### PR DESCRIPTION
Adds tests for translating civic evidence to GraphKB relevance. The commented out tests are in prep for work being done in #9 