### PR TITLE
Feature/civic evidence direction1

### DIFF
--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -117,31 +117,32 @@ const validateEvidenceSpec = ajv.compile({
 const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificance) => {
     switch (evidenceType) { // eslint-disable-line default-case
         case 'Predictive': {
-            switch (clinicalSignificance) { // eslint-disable-line default-case
-                case 'Sensitivity': {
-                    switch (evidenceDirection) { // eslint-disable-line default-case
-                        case 'Does Not Support': { return 'no response'; }
+            if (evidenceDirection == 'Does Not Support') {
+                switch (clinicalSignificance) { // eslint-disable-line default-case
+                    case 'Sensitivity':
 
-                        case 'Supports': { return clinicalSignificance.toLowerCase(); }
+                    case 'Sensitivity/Response': {
+                        return 'no response';
                     }
                 }
-                case 'Adverse Response':
 
-                case 'Reduced Sensitivity':
+            } else if (evidenceDirection == 'Supports') {
+                switch (clinicalSignificance) { // eslint-disable-line default-case
+                    case 'Sensitivity':
+                    case 'Adverse Response':
+                    case 'Reduced Sensitivity':
 
-                case 'Resistance': {
-                    return clinicalSignificance.toLowerCase();
-                }
-
-                case 'Sensitivity/Response': {
-                    switch (evidenceDirection) { // eslint-disable-line default-case
-                        case 'Does Not Support': { return 'no response'; }
-
-                        case 'Supports': { return 'sensitivity'; }
+                    case 'Resistance': {
+                        return clinicalSignificance.toLowerCase();
                     }
+
+                    case 'Sensitivity/Response': { return 'sensitivity'; }
                 }
             }
-            break;
+
+            throw new Error(
+                `unable to process relevance (${JSON.stringify({ clinicalSignificance, evidenceDirection, evidenceType })})`,
+            );
         }
 
         case 'Functional': {
@@ -588,7 +589,6 @@ const downloadEvidenceRecords = async (baseUrl) => {
 
         if (
             record.clinical_significance === 'N/A'
-            // || record.evidence_direction === 'Does Not Support'
             || (record.clinical_significance === null && record.evidence_type === 'Predictive')
         ) {
             counts.skip++;

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -588,7 +588,7 @@ const downloadEvidenceRecords = async (baseUrl) => {
 
         if (
             record.clinical_significance === 'N/A'
-//            || record.evidence_direction === 'Does Not Support'
+            //|| record.evidence_direction === 'Does Not Support'
             || (record.clinical_significance === null && record.evidence_type === 'Predictive')
         ) {
             counts.skip++;

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -119,24 +119,21 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
         case 'Predictive': {
             switch (clinicalSignificance) { // eslint-disable-line default-case
                 case 'Sensitivity':
-                    switch (evidenceDirection) {
+                    switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }
                         case 'Supports': { return clinicalSignificance.toLowerCase(); }
                     }
-
                 case 'Adverse Response':
                 case 'Reduced Sensitivity':
 
                 case 'Resistance': {
                     return clinicalSignificance.toLowerCase();
                 }
-
                 case 'Sensitivity/Response':
-                    switch (evidenceDirection) {
+                    switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }
                         case 'Supports': { return 'sensitivity'; }
                     }
-
             }
             break;
         }

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -121,10 +121,12 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                 case 'Sensitivity': {
                     switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }
+
                         case 'Supports': { return clinicalSignificance.toLowerCase(); }
                     }
                 }
                 case 'Adverse Response':
+
                 case 'Reduced Sensitivity':
 
                 case 'Resistance': {
@@ -133,6 +135,7 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                 case 'Sensitivity/Response': {
                     switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }
+
                         case 'Supports': { return 'sensitivity'; }
                     }
                 }

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -117,7 +117,7 @@ const validateEvidenceSpec = ajv.compile({
 const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificance) => {
     switch (evidenceType) { // eslint-disable-line default-case
         case 'Predictive': {
-            if (evidenceDirection == 'Does Not Support') {
+            if (evidenceDirection === 'Does Not Support') {
                 switch (clinicalSignificance) { // eslint-disable-line default-case
                     case 'Sensitivity':
 
@@ -125,8 +125,7 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                         return 'no response';
                     }
                 }
-
-            } else if (evidenceDirection == 'Supports') {
+            } else if (evidenceDirection === 'Supports') {
                 switch (clinicalSignificance) { // eslint-disable-line default-case
                     case 'Sensitivity':
                     case 'Adverse Response':

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -119,6 +119,11 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
         case 'Predictive': {
             switch (clinicalSignificance) { // eslint-disable-line default-case
                 case 'Sensitivity':
+                    switch (evidenceDirection) {
+                        case 'Does Not Support': { return 'no response'; }
+                        case 'Supports': { return clinicalSignificance.toLowerCase(); }
+                    }
+
                 case 'Adverse Response':
                 case 'Reduced Sensitivity':
 
@@ -126,7 +131,12 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                     return clinicalSignificance.toLowerCase();
                 }
 
-                case 'Sensitivity/Response': { return 'sensitivity'; }
+                case 'Sensitivity/Response':
+                    switch (evidenceDirection) {
+                        case 'Does Not Support': { return 'no response'; }
+                        case 'Supports': { return 'sensitivity'; }
+                    }
+
             }
             break;
         }

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -138,10 +138,7 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                     case 'Sensitivity/Response': { return 'sensitivity'; }
                 }
             }
-
-            throw new Error(
-                `unable to process relevance (${JSON.stringify({ clinicalSignificance, evidenceDirection, evidenceType })})`,
-            );
+            break;
         }
 
         case 'Functional': {

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -588,7 +588,7 @@ const downloadEvidenceRecords = async (baseUrl) => {
 
         if (
             record.clinical_significance === 'N/A'
-            || record.evidence_direction === 'Does Not Support'
+//            || record.evidence_direction === 'Does Not Support'
             || (record.clinical_significance === null && record.evidence_type === 'Predictive')
         ) {
             counts.skip++;

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -132,6 +132,7 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                 case 'Resistance': {
                     return clinicalSignificance.toLowerCase();
                 }
+
                 case 'Sensitivity/Response': {
                     switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -588,7 +588,7 @@ const downloadEvidenceRecords = async (baseUrl) => {
 
         if (
             record.clinical_significance === 'N/A'
-            //|| record.evidence_direction === 'Does Not Support'
+            // || record.evidence_direction === 'Does Not Support'
             || (record.clinical_significance === null && record.evidence_type === 'Predictive')
         ) {
             counts.skip++;

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -118,22 +118,24 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
     switch (evidenceType) { // eslint-disable-line default-case
         case 'Predictive': {
             switch (clinicalSignificance) { // eslint-disable-line default-case
-                case 'Sensitivity':
+                case 'Sensitivity': {
                     switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }
                         case 'Supports': { return clinicalSignificance.toLowerCase(); }
                     }
+                }
                 case 'Adverse Response':
                 case 'Reduced Sensitivity':
 
                 case 'Resistance': {
                     return clinicalSignificance.toLowerCase();
                 }
-                case 'Sensitivity/Response':
+                case 'Sensitivity/Response': {
                     switch (evidenceDirection) { // eslint-disable-line default-case
                         case 'Does Not Support': { return 'no response'; }
                         case 'Supports': { return 'sensitivity'; }
                     }
+                }
             }
             break;
         }

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -258,25 +258,6 @@ describe('normalizeVariantRecord', () => {
         ]);
     });
 
-    test('fusion with new exon position notation', () => {
-        // EML4-ALK e20-e20
-        // ALK FUSIONS
-        const variants = normalizeVariantRecord({
-            entrezId: 1,
-            entrezName: 'ALK',
-            name: 'EML4-ALK e20-e20',
-        });
-        expect(variants).toEqual([
-            {
-                positional: true,
-                reference1: { name: 'eml4' },
-                reference2: { name: 'alk', sourceId: '1' },
-                variant: 'fusion(e.20,e.20)',
-            },
-        ]);
-    });
-
-
     test('fusion with reference2 input gene', () => {
         // EML4-ALK E20;A20
         // ALK FUSIONS

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -635,8 +635,8 @@ describe('translateRelevance', () => {
         ['Predisposing', 'Supports', 'Pathogenic', 'pathogenic'],
         ['Predisposing', 'Supports', 'Likely Pathogenic', 'likely pathogenic'],
         ['Functional', 'Supports', 'Gain of Function', 'gain of function'],
-        // ['Predictive', 'Does not Support', 'Sensitivity', 'no response'],
-        // ['Predictive', 'Does not Support', 'Sensitivity/Response', 'no response'],
+        ['Predictive', 'Does not Support', 'Sensitivity', 'no response'],
+        ['Predictive', 'Does not Support', 'Sensitivity/Response', 'no response'],
     ])(
         '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -258,6 +258,25 @@ describe('normalizeVariantRecord', () => {
         ]);
     });
 
+    test('fusion with new exon position notation', () => {
+        // EML4-ALK e20-e20
+        // ALK FUSIONS
+        const variants = normalizeVariantRecord({
+            entrezId: 1,
+            entrezName: 'ALK',
+            name: 'EML4-ALK e20-e20',
+        });
+        expect(variants).toEqual([
+            {
+                positional: true,
+                reference1: { name: 'eml4' },
+                reference2: { name: 'alk', sourceId: '1' },
+                variant: 'fusion(e.20,e.20)',
+            },
+        ]);
+    });
+
+
     test('fusion with reference2 input gene', () => {
         // EML4-ALK E20;A20
         // ALK FUSIONS

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -635,8 +635,8 @@ describe('translateRelevance', () => {
         ['Predisposing', 'Supports', 'Pathogenic', 'pathogenic'],
         ['Predisposing', 'Supports', 'Likely Pathogenic', 'likely pathogenic'],
         ['Functional', 'Supports', 'Gain of Function', 'gain of function'],
-        ['Predictive', 'Does not Support', 'Sensitivity', 'no response'],
-        ['Predictive', 'Does not Support', 'Sensitivity/Response', 'no response'],
+        ['Predictive', 'Does Not Support', 'Sensitivity', 'no response'],
+        ['Predictive', 'Does Not Support', 'Sensitivity/Response', 'no response'],
     ])(
         '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);


### PR DESCRIPTION
Add support for importing CIViC evidence with evidence direction='Does Not Support' and clinical significance='Sensitivity/Response'. These statements will have relevance of 'no response'.