### PR TITLE
fix(ncit): fix subclass relationship loader

### DIFF
--- a/bin/load.js
+++ b/bin/load.js
@@ -86,6 +86,11 @@ fileParser.add_argument('input', {
     help: 'path to the file/dir to be loaded',
     type: fileExists,
 });
+fileParser.add_argument('--ignoreCache', {
+    action: 'store_true',
+    default: false,
+    help: 'Load the full content, to not check for previously loaded records already in the GraphKB instance',
+});
 
 const civicParser = subparsers.add_parser('civic');
 civicParser.add_argument('--trustedCurators', {


### PR DESCRIPTION
New Features
- command line option to turn off caching

Bug Fixes
- (ncit) Fix subclass relationship loader where relationships were not being loaded due to a bad array format

Improvements
- remove redudant use of caching key function and just use sourceId property instead