### PR TITLE
Sync deleted evidence items from CIViC

### DIFF
--- a/src/graphkb.js
+++ b/src/graphkb.js
@@ -212,6 +212,7 @@ class ApiConnection {
         this.exp = null;
         this.created = {};
         this.updated = {};
+        this.deleted = {};
         this.pendingRequests = 0;
     }
 
@@ -321,6 +322,10 @@ class ApiConnection {
 
         for (const key of Object.keys(this.updated)) {
             created[key] = { ...(created[key] || {}), updated: this.updated[key].length };
+        }
+
+        for (const key of Object.keys(this.deleted)) {
+            created[key] = { ...(created[key] || {}), updated: this.deleted[key].length };
         }
         return created;
     }
@@ -520,6 +525,11 @@ class ApiConnection {
             method: 'DELETE',
             uri: `${model.routeName}/${recordId.replace(/^#/, '')}`,
         }));
+
+        if (this.deleted[target] === undefined) {
+            this.deleted[target] = [];
+        }
+        this.deleted[target].push(recordId);
         return result;
     }
 


### PR DESCRIPTION
New Features
- Fetches a list of rejected evidence from CIViC and deletes any of these that were previously loaded by GraphKB
- Deletes any entries from GraphKB that were previously loaded but have changed to be a type of relevance we no longer support
- Keeps track of records that are deleted in the GraphKB API counts tracking data that counts create/updated records