### PR TITLE
Bug/civic doesnotsupport

### DIFF
--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -181,7 +181,6 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                 break;
             }
         }
-        break;
     }
 
     throw new Error(

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -141,14 +141,7 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
         }
 
         case 'Functional': {
-            if (evidenceDirection === 'Does Not Support') {
-                throw new Error(
-                    `unable to process relevance (${JSON.stringify({ clinicalSignificance, evidenceDirection, evidenceType })})`,
-                );
-            } else if (evidenceDirection === 'Supports') {
-                return clinicalSignificance.toLowerCase();
-            }
-            break;
+            return clinicalSignificance.toLowerCase();
         }
 
         case 'Diagnostic': {

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -141,7 +141,10 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
         }
 
         case 'Functional': {
-            return clinicalSignificance.toLowerCase();
+            if (evidenceDirection === 'Does Not Support') {
+                break;
+            } else if (evidenceDirection === 'Supports') {
+                return clinicalSignificance.toLowerCase();
         }
 
         case 'Diagnostic': {

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -114,17 +114,19 @@ const validateEvidenceSpec = ajv.compile({
  * Extract the appropriate GraphKB relevance term from a CIViC evidence record
  */
 const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificance) => {
-    switch (evidenceType) { // eslint-disable-line default-case
-        case 'Predictive': {
-            if (evidenceDirection === 'Does Not Support') {
-                switch (clinicalSignificance) { // eslint-disable-line default-case
-                    case 'Sensitivity':
+    if (evidenceDirection === 'Does Not Support') {
+        if (evidenceType === 'Predictive') {
+            switch (clinicalSignificance) { // eslint-disable-line default-case
+                case 'Sensitivity':
 
-                    case 'Sensitivity/Response': {
-                        return 'no response';
-                    }
+                case 'Sensitivity/Response': {
+                    return 'no response';
                 }
-            } else if (evidenceDirection === 'Supports') {
+            }
+        }
+    } else if (evidenceDirection === 'Supports') {
+        switch (evidenceType) { // eslint-disable-line default-case
+            case 'Predictive': {
                 switch (clinicalSignificance) { // eslint-disable-line default-case
                     case 'Sensitivity':
                     case 'Adverse Response':
@@ -135,50 +137,52 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                     }
 
                     case 'Sensitivity/Response': { return 'sensitivity'; }
+                    }
                 }
+                break;
             }
-            break;
-        }
 
-        case 'Functional': {
-            return clinicalSignificance.toLowerCase();
-        }
-
-        case 'Diagnostic': {
-            switch (clinicalSignificance) { // eslint-disable-line default-case
-                case 'Positive': { return 'favours diagnosis'; }
-
-                case 'Negative': { return 'opposes diagnosis'; }
-            }
-            break;
-        }
-
-        case 'Prognostic': {
-            switch (clinicalSignificance) { // eslint-disable-line default-case
-                case 'Negative':
-
-                case 'Poor Outcome': {
-                    return 'unfavourable prognosis';
-                }
-                case 'Positive':
-
-                case 'Better Outcome': {
-                    return 'favourable prognosis';
-                }
-            }
-            break;
-        }
-
-        case 'Predisposing': {
-            if (['Positive', null, 'null'].includes(clinicalSignificance)) {
-                return 'predisposing';
-            } if (clinicalSignificance.includes('Pathogenic')) {
+            case 'Functional': {
                 return clinicalSignificance.toLowerCase();
-            } if (clinicalSignificance === 'Uncertain Significance') {
-                return 'likely predisposing';
             }
-            break;
+
+            case 'Diagnostic': {
+                switch (clinicalSignificance) { // eslint-disable-line default-case
+                    case 'Positive': { return 'favours diagnosis'; }
+
+                    case 'Negative': { return 'opposes diagnosis'; }
+                }
+                break;
+            }
+
+            case 'Prognostic': {
+                switch (clinicalSignificance) { // eslint-disable-line default-case
+                    case 'Negative':
+
+                    case 'Poor Outcome': {
+                        return 'unfavourable prognosis';
+                    }
+                    case 'Positive':
+
+                    case 'Better Outcome': {
+                        return 'favourable prognosis';
+                    }
+                }
+                break;
+            }
+
+            case 'Predisposing': {
+                if (['Positive', null, 'null'].includes(clinicalSignificance)) {
+                    return 'predisposing';
+                } if (clinicalSignificance.includes('Pathogenic')) {
+                    return clinicalSignificance.toLowerCase();
+                } if (clinicalSignificance === 'Uncertain Significance') {
+                    return 'likely predisposing';
+                }
+                break;
+            }
         }
+        break;
     }
 
     throw new Error(

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -137,7 +137,6 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
                     }
 
                     case 'Sensitivity/Response': { return 'sensitivity'; }
-                    }
                 }
                 break;
             }

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -142,7 +142,6 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
 
         case 'Functional': {
             if (evidenceDirection === 'Does Not Support') {
-
                 throw new Error(
                     `unable to process relevance (${JSON.stringify({ clinicalSignificance, evidenceDirection, evidenceType })})`,
                 );

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -142,9 +142,14 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
 
         case 'Functional': {
             if (evidenceDirection === 'Does Not Support') {
-                break;
+
+                throw new Error(
+                    `unable to process relevance (${JSON.stringify({ clinicalSignificance, evidenceDirection, evidenceType })})`,
+                );
             } else if (evidenceDirection === 'Supports') {
                 return clinicalSignificance.toLowerCase();
+            }
+            break;
         }
 
         case 'Diagnostic': {

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -665,7 +665,7 @@ describe('translateRelevance', () => {
     test.each([
         // For EvType-EvDir-ClinSign test cases that should not be loaded
         ['Predictive', 'Does Not Support', 'Resistance'],
-        ['Prognostic', 'Does Not Support', 'Poor outcome'],
+        ['Prognostic', 'Does Not Support', 'Poor Outcome'],
         ['Functional', 'Does Not Support', 'Neomorphic'],
         ['Predisposing', 'Does Not Support', 'Positive'],
         ['Diagnostic', 'Does Not Support', 'Positive'],

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -657,6 +657,8 @@ describe('translateRelevance', () => {
         ['Predictive', 'Does Not Support', 'Sensitivity/Response', 'no response'],
         ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
         ['Functional', 'Supports', 'Neomorphic', 'neomorphic'],
+        ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
+        ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
     ])(
         '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -655,10 +655,10 @@ describe('translateRelevance', () => {
         ['Functional', 'Supports', 'Gain of Function', 'gain of function'],
         ['Predictive', 'Does Not Support', 'Sensitivity', 'no response'],
         ['Predictive', 'Does Not Support', 'Sensitivity/Response', 'no response'],
-        ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
+        // ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
         ['Functional', 'Supports', 'Neomorphic', 'neomorphic'],
-        ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
-        ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
+        // ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
+        // ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
     ])(
         '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -661,6 +661,7 @@ describe('translateRelevance', () => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);
         },
     );
+
     test.each([
         // For EvType-EvDir-ClinSign test cases that should not be loaded
         ['Predictive', 'Does Not Support', 'Resistance', 'no resistance'],
@@ -670,8 +671,9 @@ describe('translateRelevance', () => {
         ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
         ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
     ])(
-        '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
+        '%s|%s|%s errors', (evidenceType, evidenceDirection, clinicalSignificance) => {
             expect(() => translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toThrow('unable to process relevance');
         },
     );
 });
+v

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -655,6 +655,8 @@ describe('translateRelevance', () => {
         ['Functional', 'Supports', 'Gain of Function', 'gain of function'],
         ['Predictive', 'Does Not Support', 'Sensitivity', 'no response'],
         ['Predictive', 'Does Not Support', 'Sensitivity/Response', 'no response'],
+        ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
+        ['Functional', 'Supports', 'Neomorphic', 'neomorphic'],
     ])(
         '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -655,13 +655,23 @@ describe('translateRelevance', () => {
         ['Functional', 'Supports', 'Gain of Function', 'gain of function'],
         ['Predictive', 'Does Not Support', 'Sensitivity', 'no response'],
         ['Predictive', 'Does Not Support', 'Sensitivity/Response', 'no response'],
-        // ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
         ['Functional', 'Supports', 'Neomorphic', 'neomorphic'],
-        // ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
-        // ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
     ])(
         '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
             expect(translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toEqual(expected);
+        },
+    );
+    test.each([
+        // For EvType-EvDir-ClinSign test cases that should not be loaded
+        ['Predictive', 'Does Not Support', 'Resistance', 'no resistance'],
+        ['Prognostic', 'Does Not Support', 'Poor outcome', 'worse outcome'],
+        ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
+        ['Predisposing', 'Does Not Support', 'Positive', 'favours diagnosis'],
+        ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
+        ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
+    ])(
+        '%s|%s|%s returns %s', (evidenceType, evidenceDirection, clinicalSignificance, expected) => {
+            expect(() => translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toThrow('unable to process relevance');
         },
     );
 });

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -664,12 +664,12 @@ describe('translateRelevance', () => {
 
     test.each([
         // For EvType-EvDir-ClinSign test cases that should not be loaded
-        ['Predictive', 'Does Not Support', 'Resistance', 'no resistance'],
-        ['Prognostic', 'Does Not Support', 'Poor outcome', 'worse outcome'],
-        ['Functional', 'Does Not Support', 'Neomorphic', 'neomorphic'],
-        ['Predisposing', 'Does Not Support', 'Positive', 'favours diagnosis'],
-        ['Diagnostic', 'Does Not Support', 'Positive', 'favours diagnosis'],
-        ['Diagnostic', 'Does Not Support', 'Negative', 'opposes diagnosis'],
+        ['Predictive', 'Does Not Support', 'Resistance'],
+        ['Prognostic', 'Does Not Support', 'Poor outcome'],
+        ['Functional', 'Does Not Support', 'Neomorphic'],
+        ['Predisposing', 'Does Not Support', 'Positive'],
+        ['Diagnostic', 'Does Not Support', 'Positive'],
+        ['Diagnostic', 'Does Not Support', 'Negative'],
     ])(
         '%s|%s|%s errors', (evidenceType, evidenceDirection, clinicalSignificance) => {
             expect(() => translateRelevance(evidenceType, evidenceDirection, clinicalSignificance)).toThrow('unable to process relevance');

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -668,6 +668,7 @@ describe('translateRelevance', () => {
         ['Prognostic', 'Does Not Support', 'Poor Outcome'],
         ['Functional', 'Does Not Support', 'Neomorphic'],
         ['Predisposing', 'Does Not Support', 'Positive'],
+        ['Predisposing', 'N/A', 'N/A'],
         ['Diagnostic', 'Does Not Support', 'Positive'],
         ['Diagnostic', 'Does Not Support', 'Negative'],
     ])(

--- a/test/civic.test.js
+++ b/test/civic.test.js
@@ -676,4 +676,3 @@ describe('translateRelevance', () => {
         },
     );
 });
-v


### PR DESCRIPTION
Bug Fixes:

- add top-level if/else statement for CIViC Evidence direction to avoid loading unwanted statements
- add new tests for translateRelevance for those combinations of Evidence type - Evidence direction - Clinical significance that are not supported and should throw an error