### PR TITLE
Fix linkFeatureToParent() in ensembl loader

### DIFF
--- a/src/ensembl/index.js
+++ b/src/ensembl/index.js
@@ -50,6 +50,7 @@ const generalize = async (conn, record) => {
  */
 const linkFeatureToParent = async (conn, transcript, parentBiotype = 'gene') => {
     const { Parent: geneId } = await requestWithRetry({
+        json: true,
         method: 'GET',
         uri: `${BASE_URL}/lookup/id/${transcript.sourceId}`,
     });


### PR DESCRIPTION
Turns out fetchAndLoadById() were not able to load transcript's parent gene to DB because linkFeatureToParent() was requesting a text response instead of a json from Ensembl Api, which then could not be parsed adequatly.