### PR TITLE
Fix uploadRecord in hgnc loader for alias_symbol

### DIFF
--- a/src/hgnc/index.js
+++ b/src/hgnc/index.js
@@ -127,7 +127,7 @@ const uploadRecord = async ({
         const { sourceId, biotype } = currentRecord;
 
         try {
-            const aliasRecord = await this.addRecord({
+            const aliasRecord = await conn.addRecord({
                 content: {
                     biotype,
                     dependency: rid(currentRecord),


### PR DESCRIPTION
Bad object reference in the hgnc loader uploadRecord's function leaded to uncatch error then lack of Feature vertices for alias genes and their associated AliasOf edges in graphKb database.