### PR TITLE
92 demonstrate using node fetch to get query data via civic v2 graphql

### DIFF
--- a/src/civic/evidenceItemsQuery.graphql
+++ b/src/civic/evidenceItemsQuery.graphql
@@ -1,0 +1,98 @@
+query evidenceItems(
+  $after: String
+  $assertionId: Int
+  $before: String
+  $clinicalSignificance: EvidenceClinicalSignificance
+  $clinicalTrialId: Int
+  $description: String
+  $diseaseId: Int
+  $diseaseName: String
+  $drugId: Int
+  $drugName: String
+  $evidenceDirection: EvidenceDirection
+  $evidenceLevel: EvidenceLevel
+  $evidenceRating: Int
+  $evidenceType: EvidenceType
+  $first: Int
+  $geneSymbol: String
+  $id: Int
+  $last: Int
+  $organizationId: Int
+  $phenotypeId: Int
+  $sortBy: EvidenceSort
+  $sourceId: Int
+  $status: EvidenceStatus
+  $userId: Int
+  $variantId: Int
+  $variantName: String
+  $variantOrigin: VariantOrigin
+) {
+  evidenceItems(
+    after: $after
+    assertionId: $assertionId
+    before: $before
+    clinicalSignificance: $clinicalSignificance
+    clinicalTrialId: $clinicalTrialId
+    description: $description
+    diseaseId: $diseaseId
+    diseaseName: $diseaseName
+    drugId: $drugId
+    drugName: $drugName
+    evidenceDirection: $evidenceDirection
+    evidenceLevel: $evidenceLevel
+    evidenceRating: $evidenceRating
+    evidenceType: $evidenceType
+    first: $first
+    geneSymbol: $geneSymbol
+    id: $id
+    last: $last
+    organizationId: $organizationId
+    phenotypeId: $phenotypeId
+    sortBy: $sortBy
+    sourceId: $sourceId
+    status: $status
+    userId: $userId
+    variantId: $variantId
+    variantName: $variantName
+    variantOrigin: $variantOrigin
+  ) {
+    nodes {
+      id
+      status
+      variant {
+        name
+        id
+      }
+      gene {
+        name
+        id
+      }
+      evidenceType
+      evidenceLevel
+      evidenceRating
+      evidenceDirection
+      phenotypes {
+        id
+        hpoId
+      }
+      description
+      disease {
+        id
+        doid
+        name
+      }
+      drugs {
+        id
+        ncitId
+        name
+      }
+      drugInteractionType
+    }
+    pageCount
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    totalCount
+  }
+}

--- a/src/civic/v2.js
+++ b/src/civic/v2.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const { logger } = require('../logging');
+const { request } = require('../util');
+
+const uri = 'https://civicdb.org/api/graphql';
+
+
+const queryApiV2 = async (opt) => {
+    try {
+        return await request({
+            body: { ...opt },
+            json: true,
+            method: 'POST',
+            uri,
+        });
+    } catch (err) {
+        logger.error(err);
+        throw err;
+    }
+};
+
+
+const getAllPages = async (opt) => {
+    const allPages = [];
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+        const page = await queryApiV2(opt);
+        allPages.push({ ...page });
+        opt.variables = { ...opt.variables, after: page.data.evidenceItems.pageInfo.endCursor };
+        hasNextPage = page.data.evidenceItems.pageInfo.hasNextPage;
+    }
+    return allPages;
+};
+
+
+const getEvidenceItems = async (filter) => {
+    try {
+        const query = fs.readFileSync(`${process.cwd()}/src/civic/evidenceItemsQuery.graphql`).toString();
+        const pagesize = 25;
+        const allPages = await getAllPages({ query, variables: { ...filter, first: pagesize } });
+
+        // Concatenate nodes
+        const nodes = [];
+        allPages.forEach(el => {
+            nodes.push(...el.data.evidenceItems.nodes);
+        });
+        const data = { ...allPages[0] };
+        data.data.evidenceItems.nodes = nodes;
+
+        // For now, Write data to file & log infos
+        fs.writeFileSync(`${process.cwd()}/src/civic/evidenceItemsData.json`, JSON.stringify(data));
+        logger.info(`
+            totalCount: ${data.data.evidenceItems.totalCount}
+            pagesize: ${pagesize}
+            pageCount: ${data.data.evidenceItems.pageCount}
+        `);
+        return data;
+    } catch (err) {
+        logger.error(err);
+        throw err;
+    }
+};
+
+
+// Querring CIVIC v2 Api
+const filter = { diseaseId: 20 };
+getEvidenceItems(filter)
+    .then(data => {
+        logger.info(`
+            NbNodes: ${data.data.evidenceItems.nodes.length}
+        `);
+    });
+
+
+module.exports = {
+    getAllPages,
+    getEvidenceItems,
+    queryApiV2,
+};


### PR DESCRIPTION
I used the src/util.js request function instead of the fetch-node module directly since it was easy to recycle the former into querrying GraphQL.

I put the query defenition in a seperate .graphql file for ease of use, with all the available filters so they are easy to implement.

Functions in v2.js :
 - queryApiV2() : Single Api query
 - getAllPages() : Given a page size, makes as many calls to queryApiV2() as needed in order to get all records
 - getEvidenceItems() : Implementation for that specific Type. Write to file for now, only for testing purpose.
