### PR TITLE
Update Civic loader for API v2

### DIFF
--- a/src/civic/evidenceItems.graphql
+++ b/src/civic/evidenceItems.graphql
@@ -1,0 +1,111 @@
+query evidenceItems(
+  $after: String
+  $assertionId: Int
+  $before: String
+  $clinicalSignificance: EvidenceClinicalSignificance
+  $clinicalTrialId: Int
+  $description: String
+  $diseaseId: Int
+  $diseaseName: String
+  $drugId: Int
+  $drugName: String
+  $evidenceDirection: EvidenceDirection
+  $evidenceLevel: EvidenceLevel
+  $evidenceRating: Int
+  $evidenceType: EvidenceType
+  $first: Int
+  $geneSymbol: String
+  $id: Int
+  $last: Int
+  $organizationId: Int
+  $phenotypeId: Int
+  $sortBy: EvidenceSort
+  $sourceId: Int
+  $status: EvidenceStatus
+  $userId: Int
+  $variantId: Int
+  $variantName: String
+  $variantOrigin: VariantOrigin
+) {
+  evidenceItems(
+    after: $after
+    assertionId: $assertionId
+    before: $before
+    clinicalSignificance: $clinicalSignificance
+    clinicalTrialId: $clinicalTrialId
+    description: $description
+    diseaseId: $diseaseId
+    diseaseName: $diseaseName
+    drugId: $drugId
+    drugName: $drugName
+    evidenceDirection: $evidenceDirection
+    evidenceLevel: $evidenceLevel
+    evidenceRating: $evidenceRating
+    evidenceType: $evidenceType
+    first: $first
+    geneSymbol: $geneSymbol
+    id: $id
+    last: $last
+    organizationId: $organizationId
+    phenotypeId: $phenotypeId
+    sortBy: $sortBy
+    sourceId: $sourceId
+    status: $status
+    userId: $userId
+    variantId: $variantId
+    variantName: $variantName
+    variantOrigin: $variantOrigin
+  ) {
+    nodes {
+      clinicalSignificance
+      description
+      disease {
+        doid
+        id
+        name
+      }
+      drugInteractionType
+      drugs {
+        id
+        name
+        ncitId
+      }
+      evidenceDirection
+      evidenceLevel
+      evidenceRating
+      evidenceType
+      gene {
+        id
+        name
+      }
+      id
+      phenotypes {
+        hpoId
+        id
+      }
+      source {
+        ascoAbstractId
+        citationId
+        name
+        publicationYear
+        sourceType
+        sourceUrl
+      }
+      status
+      variant {
+        gene {
+          entrezId
+          name
+        }
+        id
+        name
+      }
+    }
+    pageCount
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    totalCount
+  }
+}

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -4,6 +4,7 @@
 const _ = require('lodash');
 const Ajv = require('ajv');
 const fs = require('fs');
+const path = require('path');
 
 const { error: { ErrorMixin } } = require('@bcgsc-pori/graphkb-parser');
 
@@ -17,31 +18,31 @@ const { logger } = require('../logging');
 const _pubmed = require('../entrez/pubmed');
 const _entrezGene = require('../entrez/gene');
 const { civic: SOURCE_DEFN, ncit: NCIT_SOURCE_DEFN } = require('../sources');
-const { downloadVariantRecords, processVariantRecord } = require('./variant');
+const { processVariantRecord } = require('./variant');
 const { getPublication } = require('./publication');
-const { evidence: evidenceSpec } = require('./specs.json');
+const { EvidenceItem: evidenceSpec } = require('./specs.json');
 
 class NotImplementedError extends ErrorMixin {}
 
 const ajv = new Ajv();
 
-const BASE_URL = 'https://civicdb.org/api';
+const BASE_URL = 'https://civicdb.org/api/graphql';
 
 /**
- * https://civicdb.org/glossary
+ * https://docs.civicdb.org/en/latest/model/evidence/level.html
  */
 const VOCAB = {
-    1: 'Evidence likely does not belong in CIViC. Claim is not supported well by experimental evidence. Results are not reproducible, or have very small sample size. No follow-up is done to validate novel claims.',
-    2: 'Evidence is not well supported by experimental data, and little follow-up data is available. Publication is from a journal with low academic impact. Experiments may lack proper controls, have small sample size, or are not statistically convincing.',
+    1: 'Strong, well supported evidence from a lab or journal with respected academic standing. Experiments are well controlled, and results are clean and reproducible across multiple replicates. Evidence confirmed using independent methods. The study is statistically well powered.',
+    2: 'Strong, well supported evidence. Experiments are well controlled, and results are convincing. Any discrepancies from expected results are well-explained and not concerning.',
     3: 'Evidence is convincing, but not supported by a breadth of experiments. May be smaller scale projects, or novel results without many follow-up experiments. Discrepancies from expected results are explained and not concerning.',
     4: 'Strong, well supported evidence. Experiments are well controlled, and results are convincing. Any discrepancies from expected results are well-explained and not concerning.',
-    5: 'Strong, well supported evidence from a lab or journal with respected academic standing. Experiments are well controlled, and results are clean and reproducible across multiple replicates. Evidence confirmed using separate methods.',
-    A: 'Trusted association in clinical medicine that routinely informs treatment, including large scale metaanalyses, standard of care associations, and organizational recommendations.',
-    B: 'Clinical evidence from clinical trials and other primary tumor data.',
-    C: 'Case study evidence from individual case reports in peer reviewed journals.',
-    D: 'Preclinical evidence from cell line studies, mouse models, and other in vitro or in vivo models.',
-    E: 'Inferential association made from experimental data.',
-    url: 'https://civicdb.org/glossary',
+    5: 'Strong, well supported evidence from a lab or journal with respected academic standing. Experiments are well controlled, and results are clean and reproducible across multiple replicates. Evidence confirmed using independent methods. The study is statistically well powered.',
+    A: 'Proven/consensus association in human medicine.',
+    B: 'Clinical trial or other primary patient data supports association.',
+    C: 'Individual case reports from clinical journals.',
+    D: 'In vivo or in vitro models support association.',
+    E: 'Indirect evidence.',
+    url: 'https://docs.civicdb.org/en/latest/model/evidence/level.html',
 };
 
 const EVIDENCE_LEVEL_CACHE = {}; // avoid unecessary requests by caching the evidence levels
@@ -51,73 +52,98 @@ const validateEvidenceSpec = ajv.compile(evidenceSpec);
 
 
 /**
+ * Request the CIViC GraphQL API
+ */
+const requestEvidenceItems = async (url, opt) => {
+    const allRecords = [];
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+        try {
+            const page = await request({
+                body: { ...opt },
+                json: true,
+                method: 'POST',
+                uri: url,
+            });
+            allRecords.push(...page.data.evidenceItems.nodes);
+            opt.variables = { ...opt.variables, after: page.data.evidenceItems.pageInfo.endCursor };
+            hasNextPage = page.data.evidenceItems.pageInfo.hasNextPage;
+        } catch (err) {
+            logger.error(err);
+            throw (err);
+        }
+    }
+    return allRecords;
+};
+
+
+/**
  * Extract the appropriate GraphKB relevance term from a CIViC evidence record
  */
 const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificance) => {
-    if (evidenceDirection === 'Does Not Support') {
-        if (evidenceType === 'Predictive') {
+    if (evidenceDirection === 'DOES_NOT_SUPPORT') {
+        if (evidenceType === 'PREDICTIVE') {
             switch (clinicalSignificance) { // eslint-disable-line default-case
-                case 'Sensitivity':
-
-                case 'Sensitivity/Response': {
+                case 'SENSITIVITYRESPONSE': {
                     return 'no response';
                 }
 
-                case 'Resistance': { return 'no resistance'; }
+                case 'RESISTANCE': { return 'no resistance'; }
             }
         }
-    } else if (evidenceDirection === 'Supports') {
+    } else if (evidenceDirection === 'SUPPORTS') {
         switch (evidenceType) { // eslint-disable-line default-case
-            case 'Predictive': {
+            case 'PREDICTIVE': {
                 switch (clinicalSignificance) { // eslint-disable-line default-case
-                    case 'Sensitivity':
-                    case 'Adverse Response':
-                    case 'Reduced Sensitivity':
+                    // case 'Sensitivity':   <-- Deprecated ?
+                    case 'ADVERSE_RESPONSE':
+                    case 'REDUCED_SENSITIVITY':
 
-                    case 'Resistance': {
-                        return clinicalSignificance.toLowerCase();
+                    case 'RESISTANCE': {
+                        return clinicalSignificance.replace('_', ' ').toLowerCase();
                     }
 
-                    case 'Sensitivity/Response': { return 'sensitivity'; }
+                    case 'SENSITIVITYRESPONSE': { return 'sensitivity'; }
                 }
                 break;
             }
 
-            case 'Functional': {
-                return clinicalSignificance.toLowerCase();
+            case 'FUNCTIONAL': {
+                return clinicalSignificance.replace('_', ' ').toLowerCase();
             }
 
-            case 'Diagnostic': {
+            case 'DIAGNOSTIC': {
                 switch (clinicalSignificance) { // eslint-disable-line default-case
-                    case 'Positive': { return 'favours diagnosis'; }
+                    case 'POSITIVE': { return 'favours diagnosis'; }
 
-                    case 'Negative': { return 'opposes diagnosis'; }
+                    case 'NEGATIVE': { return 'opposes diagnosis'; }
                 }
                 break;
             }
 
-            case 'Prognostic': {
+            case 'PROGNOSTIC': {
                 switch (clinicalSignificance) { // eslint-disable-line default-case
-                    case 'Negative':
+                    case 'NEGATIVE':
 
-                    case 'Poor Outcome': {
+                    case 'POOR_OUTCOME': {
                         return 'unfavourable prognosis';
                     }
-                    case 'Positive':
+                    case 'POSITIVE':
 
-                    case 'Better Outcome': {
+                    case 'BETTER_OUTCOME': {
                         return 'favourable prognosis';
                     }
                 }
                 break;
             }
 
-            case 'Predisposing': {
-                if (['Positive', null, 'null'].includes(clinicalSignificance)) {
+            case 'PREDISPOSING': {
+                if (['POSITIVE', null].includes(clinicalSignificance)) {
                     return 'predisposing';
-                } if (clinicalSignificance.includes('Pathogenic')) {
-                    return clinicalSignificance.toLowerCase();
-                } if (clinicalSignificance === 'Uncertain Significance') {
+                } if (clinicalSignificance.includes('PATHOGENIC')) {
+                    return clinicalSignificance.replace('_', ' ').toLowerCase();
+                } if (clinicalSignificance === 'UNCERTAIN_SIGNIFICANCE') {
                     return 'likely predisposing';
                 }
                 break;
@@ -126,9 +152,12 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
     }
 
     throw new NotImplementedError(
-        `unable to process relevance (${JSON.stringify({ clinicalSignificance, evidenceDirection, evidenceType })})`,
+        `unable to process relevance (${JSON.stringify(
+            { clinicalSignificance, evidenceDirection, evidenceType },
+        )})`,
     );
 };
+
 
 /**
  * Convert the CIViC relevance types to GraphKB terms
@@ -136,9 +165,9 @@ const translateRelevance = (evidenceType, evidenceDirection, clinicalSignificanc
 const getRelevance = async ({ rawRecord, conn }) => {
     // translate the type to a GraphKB vocabulary term
     let relevance = translateRelevance(
-        rawRecord.evidence_type,
-        rawRecord.evidence_direction,
-        rawRecord.clinical_significance,
+        rawRecord.evidenceType,
+        rawRecord.evidenceDirection,
+        rawRecord.clinicalSignificance,
     ).toLowerCase();
 
     if (RELEVANCE_CACHE[relevance] === undefined) {
@@ -160,12 +189,12 @@ const getDrug = async (conn, drugRecord) => {
     // then use the name as a fallback
     const name = drugRecord.name.toLowerCase().trim();
 
-    if (drugRecord.ncit_id) {
+    if (drugRecord.ncitId) {
         try {
             const drug = await conn.getUniqueRecordBy({
                 filters: [
                     { source: { filters: { name: NCIT_SOURCE_DEFN.name }, target: 'Source' } },
-                    { sourceId: drugRecord.ncit_id },
+                    { sourceId: drugRecord.ncitId },
                     { name: drugRecord.name },
                 ],
                 sort: orderPreferredOntologyTerms,
@@ -173,7 +202,7 @@ const getDrug = async (conn, drugRecord) => {
             });
             return drug;
         } catch (err) {
-            logger.error(`had NCIt drug mapping (${drugRecord.ncit_id}) named (${drugRecord.name}) but failed to fetch from graphkb: ${err}`);
+            logger.error(`had NCIt drug mapping (${drugRecord.ncitId}) named (${drugRecord.name}) but failed to fetch from graphkb: ${err}`);
             throw err;
         }
     }
@@ -236,12 +265,12 @@ const getEvidenceLevel = async ({
     conn, rawRecord, sources,
 }) => {
     // get the evidenceLevel
-    let level = `${rawRecord.evidence_level}${rawRecord.rating || ''}`.toLowerCase();
+    let level = `${rawRecord.evidenceLevel}${rawRecord.evidenceRating || ''}`.toLowerCase();
 
     if (EVIDENCE_LEVEL_CACHE[level] === undefined) {
         level = await conn.addRecord({
             content: {
-                description: `${VOCAB[rawRecord.evidence_level]} ${VOCAB[rawRecord.rating] || ''}`,
+                description: `${VOCAB[rawRecord.evidenceLevel]} ${VOCAB[rawRecord.evidenceRating] || ''}`,
                 displayName: `${SOURCE_DEFN.displayName} ${level.toUpperCase()}`,
                 name: level,
                 source: rid(sources.civic),
@@ -249,7 +278,10 @@ const getEvidenceLevel = async ({
                 url: VOCAB.url,
             },
             existsOk: true,
-            fetchConditions: { AND: [{ sourceId: level }, { name: level }, { source: rid(sources.civic) }] },
+            fetchConditions: {
+                AND:
+                    [{ sourceId: level }, { name: level }, { source: rid(sources.civic) }],
+            },
             target: 'EvidenceLevel',
 
         });
@@ -269,7 +301,7 @@ const getEvidenceLevel = async ({
  * @param {object} opt.rawRecord the unparsed record from CIViC
  * @param {object} opt.sources the sources by name
  * @param {boolean} opt.oneToOne civic statements to graphkb statements is a 1 to 1 mapping
- * @param {object} opt.variantsCache keeps track of errors and results processing variants to avoid repeating
+ * @param {object} opt.variantsCache tracks errors and result processing variants to avoid repeating
  * @param
  */
 const processEvidenceRecord = async (opt) => {
@@ -280,7 +312,7 @@ const processEvidenceRecord = async (opt) => {
     const [level, relevance, [feature]] = await Promise.all([
         getEvidenceLevel(opt),
         getRelevance(opt),
-        _entrezGene.fetchAndLoadByIds(conn, [rawRecord.variant.entrez_id]),
+        _entrezGene.fetchAndLoadByIds(conn, [rawRecord.variant.gene.entrezId]),
     ]);
     let variants;
 
@@ -299,6 +331,8 @@ const processEvidenceRecord = async (opt) => {
             throw err;
         }
     }
+
+
     // get the disease by doid
     let disease;
 
@@ -332,7 +366,7 @@ const processEvidenceRecord = async (opt) => {
                 conn,
                 rid(sources.civic),
                 rawRecord.drugs,
-                (rawRecord.drug_interaction_type || '').toLowerCase(),
+                (rawRecord.drugInteractionType || '').toLowerCase(),
             );
         } catch (err) {
             logger.error(err);
@@ -350,7 +384,7 @@ const processEvidenceRecord = async (opt) => {
         evidence: [rid(publication)],
         evidenceLevel: [rid(level)],
         relevance: rid(relevance),
-        reviewStatus: (rawRecord.status === 'accepted'
+        reviewStatus: (rawRecord.status === 'ACCEPTED'
             ? 'not required'
             : 'pending'
         ),
@@ -359,7 +393,7 @@ const processEvidenceRecord = async (opt) => {
     };
 
     // create the statement and connecting edges
-    if (rawRecord.evidence_type === 'Diagnostic' || rawRecord.evidence_type === 'Predisposing') {
+    if (rawRecord.evidenceType === 'DIAGNOSTIC' || rawRecord.evidenceType === 'PREDISPOSING') {
         if (!disease) {
             throw new Error('Unable to create a diagnostic or predisposing statement without a corresponding disease');
         }
@@ -368,12 +402,12 @@ const processEvidenceRecord = async (opt) => {
         content.conditions.push(rid(disease));
     }
 
-    if (rawRecord.evidence_type === 'Predictive' && drug) {
+    if (rawRecord.evidenceType === 'PREDICTIVE' && drug) {
         content.subject = rid(drug);
-    } if (rawRecord.evidence_type === 'Prognostic') {
+    } if (rawRecord.evidenceType === 'PROGNOSTIC') {
         // get the patient vocabulary object
         content.subject = rid(await conn.getVocabularyTerm('patient'));
-    } if (rawRecord.evidence_type === 'Functional') {
+    } if (rawRecord.evidenceType === 'FUNCTIONAL') {
         content.subject = rid(feature);
     }
 
@@ -462,100 +496,78 @@ const processEvidenceRecord = async (opt) => {
  * Get a list of CIViC Evidence Items which have since been deleted.
  * Returns the list of evidence item IDs to be purged from GraphKB
  *
- * @param {string} baseUrl base url for the CIViC API
+ * @param {string} url endpoint for the CIViC API
  */
-const fetchDeletedEvidenceItems = async (baseUrl) => {
-    const urlTemplate = `${baseUrl}/evidence_items?count=500&status=rejected`;
-    let expectedPages = 1,
-        currentPage = 1;
+const fetchDeletedEvidenceItems = async (url) => {
+    const ids = new Set();
 
-    const allRecords = [];
-
-    // get the aproved entries
-    while (currentPage <= expectedPages) {
-        const url = `${urlTemplate}&page=${currentPage}`;
-        logger.info(`loading: ${url}`);
-        const resp = await request({
-            json: true,
-            method: 'GET',
-            uri: url,
-        });
-        expectedPages = resp._meta.total_pages;
-        logger.info(`loaded ${resp.records.length} records`);
-        allRecords.push(...resp.records);
-        currentPage++;
-    }
-    return allRecords.map(ev => ev.id);
+    // Get rejected evidenceItems
+    logger.info(`loading rejected evidenceItems from ${url}`);
+    const rejected = await requestEvidenceItems(url, {
+        query: `query evidenceItems($after: String, $status: EvidenceStatus) {
+                    evidenceItems(after: $after, status: $status) {
+                        nodes {id}
+                        pageCount
+                        pageInfo {endCursor, hasNextPage}
+                        totalCount
+                    }
+                }`,
+        variables: {
+            status: 'REJECTED',
+        },
+    });
+    rejected.forEach(node => ids.add(node.id));
+    logger.info(`fetched ${ids.size} rejected entries from CIViC`);
+    return ids;
 };
 
 
 /**
  * Fetch civic approved evidence entries as well as those submitted by trusted curators
  *
- * @param {string} baseUrl the base url for the request
+ * @param {string} url the endpoint for the request
  * @param {string[]} trustedCurators a list of curator IDs to also fetch submitted only evidence items for
  */
-const downloadEvidenceRecords = async (baseUrl, trustedCurators) => {
-    const urlTemplate = `${baseUrl}/evidence_items?count=500&status=accepted`;
-    // load directly from their api
+const downloadEvidenceRecords = async (url, trustedCurators) => {
+    const records = [];
+    const errorList = [];
     const counts = {
         error: 0, exists: 0, skip: 0, success: 0,
     };
-    let expectedPages = 1,
-        currentPage = 1;
 
-    const allRecords = [];
-    const errorList = [];
+    const evidenceItems = [];
+    const query = fs.readFileSync(path.join(__dirname, 'evidenceItems.graphql')).toString();
 
-    // get the aproved entries
-    while (currentPage <= expectedPages) {
-        const url = `${urlTemplate}&page=${currentPage}`;
-        logger.info(`loading: ${url}`);
-        const resp = await request({
-            json: true,
-            method: 'GET',
-            uri: url,
-        });
-        expectedPages = resp._meta.total_pages;
-        logger.info(`loaded ${resp.records.length} records`);
-        allRecords.push(...resp.records);
-        currentPage++;
-    }
+    // Get accepted evidenceItems
+    logger.info(`loading accepted evidenceItems from ${url}`);
+    const accepted = await requestEvidenceItems(url, {
+        query,
+        variables: {
+            status: 'ACCEPTED',
+        },
+    });
+    logger.info(`fetched ${accepted.length} accepted entries from CIViC`);
+    evidenceItems.push(...accepted);
 
-    // now find entries curated by trusted curators
-    const trustedSubmissions = [];
-
-    // NOTE: purposefully not async and in a for-loop to avoid spamming their API with requests
-    for (const submitter of Array.from(new Set(trustedCurators))) {
-        const { results } = await request({
-            body: {
-                entity: 'evidence_items',
-                operator: 'AND',
-                queries: [{ condition: { name: 'is_equal_to', parameters: [`${submitter}`] }, field: 'submitter_id' }],
-                save: true,
-            },
-            json: true,
-            method: 'POST',
-            uri: `${baseUrl}/evidence_items/search`,
-        });
-
-        trustedSubmissions.push(...results);
-    }
-
-    let submitted = 0;
-
-    for (const record of trustedSubmissions) {
-        if (record.status === 'submitted') {
-            submitted += 1;
-            allRecords.push(record);
+    // Get submitted evidenceItems from trusted curators
+    for (const curator of Array.from(new Set(trustedCurators))) {
+        if (!Number.isNaN(curator)) {
+            logger.info(`loading submitted evidenceItems by trusted curator ${curator} from ${url}`);
+            const submittedByATrustedCurator = await requestEvidenceItems(url, {
+                query,
+                variables: {
+                    status: 'SUBMITTED',
+                    userId: parseInt(curator, 10),
+                },
+            });
+            evidenceItems.push(...submittedByATrustedCurator);
         }
     }
-    logger.info(`loaded ${submitted} unaccepted entries from trusted submitters`);
+    const nbUnaccepted = evidenceItems.length - accepted.length;
+    logger.info(`loaded ${nbUnaccepted} unaccepted entries by trusted submitters from CIViC`);
 
-    // validate the records using the spec
-    const records = [];
-
-    for (const record of allRecords) {
+    // Validation
+    for (const record of evidenceItems) {
         try {
             checkSpec(validateEvidenceSpec, record);
         } catch (err) {
@@ -566,8 +578,8 @@ const downloadEvidenceRecords = async (baseUrl, trustedCurators) => {
         }
 
         if (
-            record.clinical_significance === 'N/A'
-            || (record.clinical_significance === null && record.evidence_type === 'Predictive')
+            record.clinicalSignificance === 'NA'
+            || (record.clinicalSignificance === null && record.evidenceType === 'PREDICTIVE')
         ) {
             counts.skip++;
             logger.debug(`skipping uninformative record (${record.id})`);
@@ -590,9 +602,11 @@ const downloadEvidenceRecords = async (baseUrl, trustedCurators) => {
 const upload = async ({
     conn, errorLogPrefix, trustedCurators, ignoreCache = false, maxRecords, url = BASE_URL,
 }) => {
-    // add the source node
+    // 1. ADDING CIVIC SOURCE TO GRAPHKB
     const source = await conn.addSource(SOURCE_DEFN);
 
+    // 2. FETCHING PREVIOUS RECORDS FROM GRAPHKB
+    // Get list of all previous statements from CIVIC in GraphKB
     let previouslyEntered = await conn.getRecords({
         filters: { source: rid(source) },
         returnProperties: ['sourceId'],
@@ -600,24 +614,26 @@ const upload = async ({
     });
     previouslyEntered = new Set(previouslyEntered.map(r => r.sourceId));
     logger.info(`Found ${previouslyEntered.size} records previously added from ${SOURCE_DEFN.name}`);
+    // Get list of all Pubmed publication reccords from GraphKB
     logger.info('caching publication records');
     _pubmed.preLoadCache(conn);
 
-    const varById = await downloadVariantRecords();
-    const { records, errorList, counts } = await downloadEvidenceRecords(url, trustedCurators);
-    const purgeableEvidenceItems = new Set(await fetchDeletedEvidenceItems(url));
-    logger.info(`fetched ${purgeableEvidenceItems.size} deleted entries from CIViC`);
+    // 3. FETCHING RECORDS FROM CIVIC
+    // Get evidence records from CIVIC (Accepted, or Submitted from a trusted curator)
+    const { counts, errorList, records } = await downloadEvidenceRecords(url, trustedCurators);
+    // Get rejected evidence records ids from CIVIC
+    const purgeableEvidenceItems = await fetchDeletedEvidenceItems(url);
 
+    // 4. PROCESSING RECORDS
     logger.info(`Processing ${records.length} records`);
-
-    // keep track of errors and already processed variants by their CIViC IDs to avoid repeat logging
+    // keep track of errors and already processed variants by their CIViC ID to avoid repeat logging
     const variantsCache = {
         errors: {},
         records: {},
     };
-
     const recordsById = {};
 
+    // Refactor records into recordsById
     for (const record of records) {
         if (!recordsById[record.id]) {
             recordsById[record.id] = [];
@@ -630,13 +646,15 @@ const upload = async ({
         }
     }
 
+    // Main loop on recordsById
     for (const [sourceId, recordList] of Object.entries(recordsById)) {
         if (previouslyEntered.has(sourceId) && !ignoreCache) {
             counts.exists++;
             continue;
         }
         if (purgeableEvidenceItems.has(sourceId)) {
-            // this should never happen, but if it does we have made an invalida assumption about how civic uses IDs
+            // this should never happen.
+            // If it does we have made an invalid assumption about how civic uses IDs.
             throw new Error(`Record ID is both deleted and to-be loaded. Violates assumptions: ${sourceId}`);
         }
         const preupload = new Set((await conn.getRecords({
@@ -649,64 +667,67 @@ const upload = async ({
         let mappedCount = 0;
         const postupload = [];
 
-        // resolve combinations
+        // Nested loop on recordList. Resolve combinations
         for (const record of recordList) {
-            record.variants = [varById[record.variant_id]]; // OR-ing of variants
-
-            if (record.drugs === undefined || record.drugs.length === 0) {
+            if (record.drugs === null || record.drugs.length === 0) {
                 record.drugs = [null];
-            } else if (record.drug_interaction_type === 'Combination' || record.drug_interaction_type === 'Sequential') {
+            } else if (
+                record.drugInteractionType === 'COMBINATION'
+                || record.drugInteractionType === 'SEQUENTIAL'
+            ) {
                 record.drugs = [record.drugs];
-            } else if (record.drug_interaction_type === 'Substitutes' || record.drugs.length < 2) {
+            } else if (record.drugInteractionType === 'SUBSTITUTES' || record.drugs.length < 2) {
                 record.drugs = record.drugs.map(drug => [drug]);
-                record.drug_interaction_type = null;
+                record.drugInteractionType = null;
             } else {
-                logger.error(`(evidence: ${record.id}) unsupported drug interaction type (${record.drug_interaction_type}) for a multiple drug (${record.drugs.length}) statement`);
+                logger.error(`(evidence: ${record.id}) unsupported drug interaction type (${record.drugInteractionType}) for a multiple drug (${record.drugs.length}) statement`);
                 counts.skip++;
                 continue;
             }
 
             let orCombination;
 
-            if (orCombination = /^([a-z]\d+)([a-z])\/([a-z])$/i.exec(record.variants[0].name)) {
+            if (orCombination = /^([a-z]\d+)([a-z])\/([a-z])$/i.exec(record.variant.name)) {
                 const [, prefix, tail1, tail2] = orCombination;
-                record.variants = [
-                    { ...record.variants[0], name: `${prefix}${tail1}` },
-                    { ...record.variants[0], name: `${prefix}${tail2}` },
+                record.variant = [
+                    { ...record.variant, name: `${prefix}${tail1}` },
+                    { ...record.variant, name: `${prefix}${tail2}` },
                 ];
             }
-            mappedCount += record.variants.length * record.drugs.length;
+            mappedCount += record.variant.length * record.drugs.length;
         }
 
         const oneToOne = mappedCount === 1 && preupload.size === 1;
 
-        // upload all GraphKB statements for this CIViC Evidence Item
+        // Nested loop on recordList. Upload all GraphKB statements for this CIViC Evidence Item
         for (const record of recordList) {
-            for (const variant of record.variants) {
-                for (const drugs of record.drugs) {
-                    try {
-                        logger.debug(`processing ${record.id}`);
-                        const result = await processEvidenceRecord({
-                            conn,
-                            oneToOne,
-                            rawRecord: { ..._.omit(record, ['drugs', 'variants']), drugs, variant },
-                            sources: { civic: source },
-                            variantsCache,
-                        });
-                        postupload.push(rid(result));
-                        counts.success += 1;
-                    } catch (err) {
-                        if (err.toString().includes('is not a function') || err.toString().includes('of undefined')) {
-                            console.error(err);
-                        }
-                        if (err instanceof NotImplementedError) {
-                            // accepted evidence that we do not support loading. Should delete as it may have changed to this from something we did support
-                            purgeableEvidenceItems.add(sourceId);
-                        }
-                        errorList.push({ error: err, errorMessage: err.toString(), record });
-                        logger.error(`evidence (${record.id}) ${err}`);
-                        counts.error += 1;
+            for (const drugs of record.drugs) {
+                try {
+                    logger.debug(`processing ${record.id}`);
+                    const result = await processEvidenceRecord({
+                        conn,
+                        oneToOne,
+                        rawRecord: { ..._.omit(record, ['drugs']), drugs },
+                        sources: { civic: source },
+                        variantsCache,
+                    });
+                    postupload.push(rid(result));
+                    counts.success += 1;
+                } catch (err) {
+                    if (
+                        err.toString().includes('is not a function')
+                            || err.toString().includes('of undefined')
+                    ) {
+                        console.error(err);
                     }
+                    if (err instanceof NotImplementedError) {
+                        // accepted evidence that we do not support loading.
+                        // Should delete as it may have changed from something we did support
+                        purgeableEvidenceItems.add(sourceId);
+                    }
+                    errorList.push({ error: err, errorMessage: err.toString(), record });
+                    logger.error(`evidence (${record.id}) ${err}`);
+                    counts.error += 1;
                 }
             }
         }
@@ -717,12 +738,16 @@ const upload = async ({
         });
 
         if (preupload.size && purgeableEvidenceItems.has(sourceId)) {
-            logger.warn(`Removing ${preupload.size} CIViC Entries (EID:${sourceId}) of unsupported format`);
+            logger.warn(`
+                Removing ${preupload.size} CIViC Entries (EID:${sourceId}) of unsupported format
+            `);
 
             try {
-                await Promise.all(Array.from(preupload).map(async outdatedId => conn.deleteRecord(
-                    'Statement', outdatedId,
-                )));
+                await Promise.all(
+                    Array.from(preupload).map(
+                        async outdatedId => conn.deleteRecord('Statement', outdatedId),
+                    ),
+                );
             } catch (err) {
                 logger.error(err);
             }
@@ -731,9 +756,11 @@ const upload = async ({
                 logger.warn(`deleting ${preupload.size} outdated statement records (${Array.from(preupload).join(' ')}) has new/retained statements (${postupload.join(' ')})`);
 
                 try {
-                    await Promise.all(Array.from(preupload).map(async outdatedId => conn.deleteRecord(
-                        'Statement', outdatedId,
-                    )));
+                    await Promise.all(
+                        Array.from(preupload).map(
+                            async outdatedId => conn.deleteRecord('Statement', outdatedId),
+                        ),
+                    );
                 } catch (err) {
                     logger.error(err);
                 }
@@ -768,6 +795,7 @@ const upload = async ({
     logger.info(`writing ${errorJson}`);
     fs.writeFileSync(errorJson, JSON.stringify(errorList, null, 2));
 };
+
 
 module.exports = {
     SOURCE_DEFN,

--- a/src/civic/specs.json
+++ b/src/civic/specs.json
@@ -1,53 +1,62 @@
 {
-    "evidence": {
+    "EvidenceItem": {
         "properties": {
-            "clinical_significance": {
+            "clinicalSignificance": {
                 "enum": [
-                    "Sensitivity",
-                    "Adverse Response",
-                    "Resistance",
-                    "Sensitivity/Response",
-                    "Reduced Sensitivity",
-                    "Positive",
-                    "Negative",
-                    "Poor Outcome",
-                    "Better Outcome",
-                    "Uncertain Significance",
-                    "Pathogenic",
-                    "Likely Pathogenic",
-                    "N/A",
-                    "Gain of Function",
-                    "Loss of Function",
-                    "Neomorphic",
-                    "Dominant Negative",
-                    "Unaltered Function",
+                    "ADVERSE_RESPONSE",
+                    "BENIGN",
+                    "BETTER_OUTCOME",
+                    "DOMINANT_NEGATIVE",
+                    "GAIN_OF_FUNCTION",
+                    "LIKELY_BENIGN",
+                    "LIKELY_PATHOGENIC",
+                    "LOSS_OF_FUNCTION",
+                    "NA",
+                    "NEGATIVE",
+                    "NEOMORPHIC",
+                    "PATHOGENIC",
+                    "POOR_OUTCOME",
+                    "POSITIVE",
+                    "REDUCED_SENSITIVITY",
+                    "RESISTANCE",
+                    "SENSITIVITYRESPONSE",
+                    "UNALTERED_FUNCTION",
+                    "UNCERTAIN_SIGNIFICANCE",
+                    "UNKNOWN",
                     null
                 ]
             },
             "description": {
-                "type": "string"
-            },
-            "disease": {
-                "oneOf": [
-                    {
-                        "doid": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "type": "object"
-                    },
-                    {
-                        "type": "null"
-                    }
+                "type": [
+                    "null",
+                    "string"
                 ]
             },
-            "drug_interaction_type": {
+            "disease": {
+                "properties": {
+                    "doid": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
+                    },
+                    "name": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": [
+                    "null",
+                    "object"
+                ]
+            },
+            "drugInteractionType": {
                 "enum": [
-                    "Combination",
-                    "Substitutes",
-                    "Sequential",
+                    "COMBINATION",
+                    "SEQUENTIAL",
+                    "SUBSTITUTES",
                     null
                 ]
             },
@@ -55,199 +64,215 @@
                 "items": {
                     "properties": {
                         "id": {
-                            "type": "number"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "ncit_id": {
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "number"
                             ]
                         },
-                        "pubchem_id": {
+                        "name": {
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ncitId": {
+                            "type": [
+                                "null",
+                                "string"
                             ]
                         }
                     },
-                    "required": [
-                        "name",
-                        "ncit_id"
-                    ],
-                    "type": "object"
+                    "type": [
+                        "null",
+                        "object"
+                    ]
                 },
-                "type": "array"
+                "type": [
+                    "array",
+                    "null"
+                ]
             },
-            "evidence_direction": {
+            "evidenceDirection": {
                 "enum": [
-                    "Supports",
-                    "N/A",
-                    "Does Not Support",
+                    "DOES_NOT_SUPPORT",
+                    "NA",
+                    "SUPPORTS",
                     null
                 ]
             },
-            "evidence_level": {
-                "type": "string"
-            },
-            "evidence_type": {
+            "evidenceLevel": {
                 "enum": [
-                    "Predictive",
-                    "Diagnostic",
-                    "Prognostic",
-                    "Predisposing",
-                    "Functional"
+                    "A",
+                    "B",
+                    "C",
+                    "D",
+                    "E",
+                    null
+                ]
+            },
+            "evidenceRating": {
+                "type": [
+                    "null",
+                    "number"
+                ]
+            },
+            "evidenceType": {
+                "enum": [
+                    "DIAGNOSTIC",
+                    "FUNCTIONAL",
+                    "ONCOGENIC",
+                    "PREDICTIVE",
+                    "PREDISPOSING",
+                    "PROGNOSTIC",
+                    null
+                ]
+            },
+            "gene": {
+                "properties": {
+                    "id": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
+                    },
+                    "name": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                },
+                "type": [
+                    "null",
+                    "object"
                 ]
             },
             "id": {
-                "type": "number"
-            },
-            "rating": {
                 "type": [
-                    "number",
+                    "null",
+                    "number"
+                ]
+            },
+            "phenotypes": {
+                "items": {
+                    "properties": {
+                        "hpoId": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "id": {
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "type": [
+                    "array",
                     "null"
                 ]
             },
             "source": {
                 "properties": {
-                    "citation_id": {
-                        "type": "string"
+                    "ascoAbstractId": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
+                    },
+                    "citationId": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
                     },
                     "name": {
                         "type": [
-                            "string",
-                            "null"
+                            "null",
+                            "string"
                         ]
                     },
-                    "source_type": {
+                    "publicationYear": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
+                    },
+                    "sourceType": {
                         "enum": [
                             "ASCO",
-                            "PubMed"
+                            "PUBMED",
+                            null
                         ]
+                    },
+                    "sourceUrl ": {
+                        "type": "string"
                     }
-                }
+                },
+                "type": [
+                    "null",
+                    "object"
+                ]
             },
             "status": {
-                "type": "string"
+                "enum": [
+                    "ACCEPTED",
+                    "REJECTED",
+                    "SUBMITTED",
+                    null
+                ]
             },
-            "variant_id": {
-                "type": "number"
-            }
-        },
-        "type": "object"
-    },
-    "variant": {
-        "properties": {
-            "civic_actionability_score": {
-                "type": "number"
-            },
-            "coordinates": {
+            "variant": {
                 "properties": {
-                    "chromosome": {
+                    "gene": {
+                        "properties": {
+                            "entrezId": {
+                                "type": [
+                                    "null",
+                                    "number"
+                                ]
+                            },
+                            "name": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
                         "type": [
-                            "string",
-                            "null"
+                            "null",
+                            "object"
                         ]
                     },
-                    "chromosome2": {
+                    "id": {
                         "type": [
-                            "string",
-                            "null"
+                            "null",
+                            "number"
                         ]
                     },
-                    "ensembl_version": {
+                    "name": {
                         "type": [
-                            "number",
-                            "null"
-                        ]
-                    },
-                    "reference_bases": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "reference_build": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "representative_transcript": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "representative_transcript2": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "start": {
-                        "type": [
-                            "number",
-                            "null"
-                        ]
-                    },
-                    "start2": {
-                        "type": [
-                            "number",
-                            "null"
-                        ]
-                    },
-                    "stop": {
-                        "type": [
-                            "number",
-                            "null"
-                        ]
-                    },
-                    "stop2": {
-                        "type": [
-                            "number",
-                            "null"
-                        ]
-                    },
-                    "variant_bases": {
-                        "type": [
-                            "string",
-                            "null"
+                            "null",
+                            "string"
                         ]
                     }
                 },
-                "type": "object"
-            },
-            "description": {
-                "type": "string"
-            },
-            "entrez_id": {
-                "type": "number"
-            },
-            "entrez_name": {
-                "type": "string"
-            },
-            "id": {
-                "type": "number"
-            },
-            "name": {
-                "type": "string"
-            },
-            "variant_types": {
-                "items": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "so_id": {
-                        "type": "string"
-                    },
-                    "type": "object"
-                },
-                "type": "array"
+                "type": [
+                    "null",
+                    "object"
+                ]
             }
         },
-        "type": "object"
+        "type": [
+            "null",
+            "object"
+        ]
     }
 }


### PR DESCRIPTION
This updates the CIViC loader to work with their new GraphQL API.
When validating the returned Json file, almost all the fields in the specs needs to be nullable even if not always specified in the occifial documentation.