### PR TITLE
Fix civic loader on api schema change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgsc-pori/graphkb-loader",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgsc-pori/graphkb-loader",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "GPL-3",
       "dependencies": {
         "@bcgsc-pori/graphkb-parser": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bcgsc-pori/graphkb-loader",
   "main": "src/index.js",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/bcgsc/pori_graphkb_loader.git"

--- a/src/civic/evidenceItems.graphql
+++ b/src/civic/evidenceItems.graphql
@@ -21,7 +21,7 @@ query evidenceItems(
   $phenotypeId: Int
   $sortBy: EvidenceSort
   $sourceId: Int
-  $status: EvidenceStatus
+  $status: EvidenceStatusFilter
   $userId: Int
   $variantId: Int
   $variantName: String

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -504,7 +504,7 @@ const fetchDeletedEvidenceItems = async (url) => {
     // Get rejected evidenceItems
     logger.info(`loading rejected evidenceItems from ${url}`);
     const rejected = await requestEvidenceItems(url, {
-        query: `query evidenceItems($after: String, $status: EvidenceStatus) {
+        query: `query evidenceItems($after: String, $status: EvidenceStatusFilter) {
                     evidenceItems(after: $after, status: $status) {
                         nodes {id}
                         pageCount


### PR DESCRIPTION
BugFixes

- Fix CIViC loader for API schema change on evidenceItems status type (from EvidenceStatus to EvidenceStatusFilter).