### PR TITLE
Release v6.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgsc-pori/graphkb-loader",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgsc-pori/graphkb-loader",
-      "version": "6.3.1",
+      "version": "6.3.2",
       "license": "GPL-3",
       "dependencies": {
         "@bcgsc-pori/graphkb-parser": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bcgsc-pori/graphkb-loader",
   "main": "src/index.js",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/bcgsc/pori_graphkb_loader.git"


### PR DESCRIPTION
Improvement

- Adds EvidenceLevel data to the ontology loader to accomodate for cross-referencing with IPR levels