### PR TITLE
Feature/kbdev 1011 update civic loader to match current civic api complexes mp

### DIFF
--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -312,7 +312,7 @@ const processEvidenceRecord = async (opt) => {
     } if (rawRecord.evidenceType === 'PROGNOSTIC') {
         // get the patient vocabulary object
         content.subject = rid(await conn.getVocabularyTerm('patient'));
-    } if (rawRecord.evidenceType === 'FUNCTIONAL' || rawRecord.evidenceType === 'ONCOGENIC') { // TO BE CONFIRMED - See in GKB !!
+    } if (rawRecord.evidenceType === 'FUNCTIONAL' || rawRecord.evidenceType === 'ONCOGENIC') {
         content.subject = rid(feature);
     }
 

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -309,7 +309,7 @@ const processEvidenceRecord = async (opt) => {
     } if (rawRecord.evidenceType === 'PROGNOSTIC') {
         // get the patient vocabulary object
         content.subject = rid(await conn.getVocabularyTerm('patient'));
-    } if (rawRecord.evidenceType === 'FUNCTIONAL') {
+    } if (rawRecord.evidenceType === 'FUNCTIONAL' || rawRecord.evidenceType === 'ONCOGENIC') { // TO BE CONFIRMED - See in GKB !!
         content.subject = rid(feature);
     }
 
@@ -478,17 +478,8 @@ const downloadEvidenceRecords = async (url, trustedCurators) => {
             counts.error++;
             continue;
         }
-
-        if (
-            record.significance === 'NA'
-            || (record.significance === null && record.evidenceType === 'PREDICTIVE')
-        ) {
-            counts.skip++;
-            logger.debug(`skipping uninformative record (${record.id})`);
-        } else {
             records.push(record);
         }
-    }
     return { counts, errorList, records };
 };
 

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const Ajv = require('ajv');
 const fs = require('fs');
 const path = require('path');
-// const util = require('util');
 
 const { error: { ErrorMixin } } = require('@bcgsc-pori/graphkb-parser');
 
@@ -548,7 +547,7 @@ const upload = async ({
             counts.skip++;
             continue;
         }
-        if (!record.molecularProfile.variants || record.molecularProfile.variants.length > 0) {
+        if (!record.molecularProfile.variants || record.molecularProfile.variants.length === 0) {
             logger.error(`Molecular Profile without Variants. Violates assumptions: ${record.molecularProfile.id}`);
             counts.skip++;
             continue;

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -485,31 +485,6 @@ const downloadEvidenceRecords = async (url, trustedCurators) => {
 
 
 /**
- * Splits a variant into a list of it's variations
- * Desambiguate variants that as been linked as "or"
- * Ex. {name: 'Q157P/R'} --> [{name: 'Q157P'}, {name: 'Q157R'}]
- * Ex. {name: 'Q157P'}   --> [{name: 'Q157P'}]
- *
- * @param {Object} variant the Variant object to desambigaute
- * @returns {Object[]} an array of Variant objects
- */
-const disambiguateVariant = (variant) => {
-    let variants = [variant],
-        orCombination;
-
-    if (orCombination = /^([a-z]\d+)([a-z])\/([a-z])$/i.exec(variant.name)) {
-        const [, prefix, tail1, tail2] = orCombination;
-        variants = [
-            { ...variant, name: `${prefix}${tail1}` },
-            { ...variant, name: `${prefix}${tail2}` },
-        ];
-    }
-
-    return variants;
-};
-
-
-/**
  * Access the CIVic API, parse content, transform and load into GraphKB
  *
  * @param {object} opt options

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -709,7 +709,6 @@ const upload = async ({
 
 module.exports = {
     SOURCE_DEFN,
-    disambiguateVariant,
     specs: { validateEvidenceSpec },
     upload,
 };

--- a/src/civic/profile.js
+++ b/src/civic/profile.js
@@ -118,6 +118,27 @@ const MolecularProfile = (molecularProfile) => ({
         }
         return conditions;
     },
+    /* Convert conditions' variant ids to variant objects */
+    _variants(conditions) {
+        // Getting variants by ids from molecular profile's variants array
+        const variantsById = {};
+        this.profile.variants.forEach((variant) => {
+            variantsById[variant.id] = variant;
+        });
+
+        // Refactoring conditions with variant objects
+        const temp = [];
+        conditions.forEach((condition) => {
+            try {
+                temp.push(condition.map(id => variantsById[id]));
+            } catch (err) {
+                throw new Error(
+                    `unable to process molecular profile with missing or misformatted variants (${this.profile.id || ''})`,
+                );
+            }
+        });
+        return temp;
+    },
     /* Main object's method. Process expression into array of conditions' arrays */
     process() {
         const { parsedName } = this.profile;
@@ -142,7 +163,10 @@ const MolecularProfile = (molecularProfile) => ({
         // Filters out unwanted gene's info from expression
         const filteredParsedName = parsedName.filter(el => !el.entrezId);
 
-        return this._parse(filteredParsedName);
+        // Parse expression into conditions and get variant objects from ids
+        return this._variants(
+            this._parse(filteredParsedName),
+        );
     },
     profile: molecularProfile || {},
 });

--- a/src/civic/profile.js
+++ b/src/civic/profile.js
@@ -1,0 +1,153 @@
+const { error: { ErrorMixin } } = require('@bcgsc-pori/graphkb-parser');
+
+class NotImplementedError extends ErrorMixin { }
+
+
+/**
+ * Factory function returning a MolecularProfile object. The process() method
+ * allows for the process of Civic's Molecular Profiles into GraphKB Statement's conditions
+ *
+ * @param {Object} molecularProfile Molecular Profile segment from GraphQL query
+ * @returns {Array[]} An array of arrays, each of which is a list of conditions for 1 GraphKB' Statement
+ */
+const MolecularProfile = (molecularProfile) => ({
+    /* Compile parsed block into array of conditions' arrays */
+    _compile({ arr, op, part }) {
+        let conditions = [];
+
+        switch (op) {
+            case 'AND':
+                arr.forEach((ArrEl) => {
+                    part.forEach((partEl) => {
+                        conditions.push([...ArrEl, ...partEl]);
+                    });
+                });
+                break;
+
+            case 'OR':
+                if (arr[0].length === 0) {
+                    conditions = [...part];
+                } else {
+                    conditions = [...arr, ...part];
+                }
+                break;
+
+            default:
+                break;
+        }
+        return conditions;
+    },
+    /* Returns index of closing parenthesis for end of block */
+    _end({ block, i, offset }) {
+        let count = 1,
+            j = 0;
+
+        while (count > 0) {
+            j++;
+
+            if (block[i + offset + j].text) {
+                switch (block[i + offset + j].text) {
+                    case '(':
+                        count++;
+                        break;
+
+                    case ')':
+                        count--;
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+        }
+        return j;
+    },
+    /* Returns true if parsedName contains NOT operator(s), otherwise false */
+    _not(parsedName) {
+        for (let i = 0; i < parsedName.length; i++) {
+            if (parsedName[i].text && parsedName[i].text === 'NOT') {
+                return true;
+            }
+        }
+        return false;
+    },
+    /* Parse block expression into array of conditions' arrays */
+    _parse(block) {
+        let conditions = [[]],
+            offset = 0,
+            op = 'OR';
+
+        for (let i = 0; i + offset < block.length; i++) {
+            const idx = i + offset;
+
+            // If Variant
+            if (block[idx].id) {
+                // Add variant condition
+                conditions = this._compile({
+                    arr: conditions,
+                    op,
+                    part: [[block[idx].id]],
+                });
+                continue;
+            }
+
+            // If Nested block
+            if (block[idx].text && block[idx].text === '(') {
+                // Get end of block' index
+                const j = this._end({
+                    block,
+                    i,
+                    offset,
+                });
+                // Recursively parse nested block
+                conditions = this._compile({
+                    arr: conditions,
+                    op,
+                    part: this._parse(block.slice(idx + 1, idx + j)),
+                });
+                // New offset for rest of current block
+                offset += j;
+                continue;
+            }
+
+            // If Operator
+            if (block[idx].text && ['AND', 'OR'].includes(block[idx].text)) {
+                op = block[idx].text;
+                continue;
+            }
+        }
+        return conditions;
+    },
+    /* Main object's method. Process expression into array of conditions' arrays */
+    process() {
+        const { parsedName } = this.profile;
+
+        // Check for expression (parsedName property) on Molecular Profile
+        if (!parsedName
+            || !Array.isArray(parsedName)
+            || parsedName.length === 0
+            || typeof parsedName[0] !== 'object'
+        ) {
+            throw new Error(
+                `unable to process molecular profile with missing or misformatted parsedName (${this.profile.id || ''})`,
+            );
+        }
+        // Check for NOT operator in expression (not yet supported)
+        if (this._not(parsedName)) {
+            throw new NotImplementedError(
+                `unable to process molecular profile with NOT operator (${this.profile.id || ''})`,
+            );
+        }
+
+        // Filters out unwanted gene's info from expression
+        const filteredParsedName = parsedName.filter(el => !el.entrezId);
+
+        return this._parse(filteredParsedName);
+    },
+    profile: molecularProfile || {},
+});
+
+
+module.exports = {
+    MolecularProfile,
+};

--- a/src/civic/profile.js
+++ b/src/civic/profile.js
@@ -129,14 +129,20 @@ const MolecularProfile = (molecularProfile) => ({
         // Refactoring conditions with variant objects
         const temp = [];
         conditions.forEach((condition) => {
-            try {
-                temp.push(condition.map(id => variantsById[id]));
-            } catch (err) {
-                throw new Error(
-                    `unable to process molecular profile with missing or misformatted variants (${this.profile.id || ''})`,
-                );
-            }
+            temp.push(condition.map(id => variantsById[id]));
         });
+
+        // Checking for missing variants
+        temp.forEach((condition) => {
+            condition.forEach((variant) => {
+                if (!variant) {
+                    throw new Error(
+                        `unable to process molecular profile with missing or misformatted variants (${this.profile.id || ''})`,
+                    );
+                }
+            });
+        });
+
         return temp;
     },
     /* Main object's method. Process expression into array of conditions' arrays */

--- a/src/civic/profile.js
+++ b/src/civic/profile.js
@@ -4,22 +4,43 @@ class NotImplementedError extends ErrorMixin { }
 
 
 /**
- * Factory function returning a MolecularProfile object. The process() method
- * allows for the process of Civic's Molecular Profiles into GraphKB Statement's conditions
+ * Factory function returning a MolecularProfile object.
+ * The process() method allows for the process of Civic's Molecular Profiles
+ * After processing, the conditions property stores an array of GraphKB Statement's conditions
  *
- * @param {Object} molecularProfile Molecular Profile segment from GraphQL query
- * @returns {Array[]} An array of arrays, each of which is a list of conditions for 1 GraphKB' Statement
+ * @param {Object} molecularProfile a Molecular Profile segment from GraphQL query
+ * @returns {MolecularProfile} object whose conditions' property is an array of lists of conditions
  */
 const MolecularProfile = (molecularProfile) => ({
+    /* Combine new conditional variants with existing conditions */
+    _combine({ arr1, arr2 }) {
+        const combinations = [];
+
+        if (arr1[0].length === 0) {
+            return arr2;
+        }
+        if (arr2[0].length === 0) {
+            return arr1;
+        }
+
+        arr1.forEach((e1) => {
+            arr2.forEach((e2) => {
+                e2.forEach((variant) => {
+                    combinations.push([...e1, variant]);
+                });
+            });
+        });
+        return combinations;
+    },
     /* Compile parsed block into array of conditions' arrays */
     _compile({ arr, op, part }) {
         let conditions = [];
 
         switch (op) {
             case 'AND':
-                arr.forEach((ArrEl) => {
+                arr.forEach((arrEl) => {
                     part.forEach((partEl) => {
-                        conditions.push([...ArrEl, ...partEl]);
+                        conditions.push([...arrEl, ...partEl]);
                     });
                 });
                 break;
@@ -36,6 +57,27 @@ const MolecularProfile = (molecularProfile) => ({
                 break;
         }
         return conditions;
+    },
+    /* Desambiguation of variants with implicit 'or' in the name */
+    _disambiguate() {
+        // Split ambiguous variants
+        const temp = [];
+        this.conditions.forEach((condition) => {
+            condition.forEach((variant) => {
+                temp.push(
+                    this._split(variant),
+                );
+            });
+        });
+
+        let newCondition;
+
+        // Combine variations into new condition
+        for (let i = 0; i < temp.length; i++) {
+            newCondition = this._combine({ arr1: newCondition || [[]], arr2: temp[i] });
+        }
+        this.conditions = newCondition;
+        return this;
     },
     /* Returns index of closing parenthesis for end of block */
     _end({ block, i, offset }) {
@@ -75,14 +117,14 @@ const MolecularProfile = (molecularProfile) => ({
     _parse(block) {
         let conditions = [[]],
             offset = 0,
-            op = 'OR';
+            op = 'OR'; // Default operator
 
         for (let i = 0; i + offset < block.length; i++) {
             const idx = i + offset;
 
             // If Variant
             if (block[idx].id) {
-                // Add variant condition
+                // Add variant as a condition
                 conditions = this._compile({
                     arr: conditions,
                     op,
@@ -118,8 +160,22 @@ const MolecularProfile = (molecularProfile) => ({
         }
         return conditions;
     },
-    /* Convert conditions' variant ids to variant objects */
-    _variants(conditions) {
+    /* Splits variant's object into it's variations
+     * Ex. {name: 'Q157P/R'} --> [[ {name: 'Q157P'} ], [ {name: 'Q157R'} ]] */
+    _split(variant) {
+        let orCombination;
+
+        if (orCombination = /^([a-z]\d+)([a-z])\/([a-z])$/i.exec(variant.name)) {
+            const [, prefix, tail1, tail2] = orCombination;
+            return [
+                [{ ...variant, name: `${prefix}${tail1}` }],
+                [{ ...variant, name: `${prefix}${tail2}` }],
+            ];
+        }
+        return [[variant]];
+    },
+    /* Convert variant ids to variant objects */
+    _variants() {
         // Getting variants by ids from molecular profile's variants array
         const variantsById = {};
         this.profile.variants.forEach((variant) => {
@@ -127,13 +183,13 @@ const MolecularProfile = (molecularProfile) => ({
         });
 
         // Refactoring conditions with variant objects
-        const temp = [];
-        conditions.forEach((condition) => {
-            temp.push(condition.map(id => variantsById[id]));
+        const newConditions = [];
+        this.conditions.forEach((condition) => {
+            newConditions.push(condition.map(id => variantsById[id]));
         });
 
-        // Checking for missing variants
-        temp.forEach((condition) => {
+        // Check if any missing variant object
+        newConditions.forEach((condition) => {
             condition.forEach((variant) => {
                 if (!variant) {
                     throw new Error(
@@ -143,13 +199,18 @@ const MolecularProfile = (molecularProfile) => ({
             });
         });
 
-        return temp;
+        // Replacing conditions with ones with variant's objects
+        this.conditions = newConditions;
+        return this;
     },
+    /* Corresponding GKB Statements' conditions (1 array per statement) */
+    conditions: [[]],
     /* Main object's method. Process expression into array of conditions' arrays */
     process() {
+        // Get Molecular Profile's expression (parsedName property)
         const { parsedName } = this.profile;
 
-        // Check for expression (parsedName property) on Molecular Profile
+        // Check for expression's format
         if (!parsedName
             || !Array.isArray(parsedName)
             || parsedName.length === 0
@@ -159,21 +220,24 @@ const MolecularProfile = (molecularProfile) => ({
                 `unable to process molecular profile with missing or misformatted parsedName (${this.profile.id || ''})`,
             );
         }
-        // Check for NOT operator in expression (not yet supported)
+        // NOT operator not yet supported
         if (this._not(parsedName)) {
             throw new NotImplementedError(
                 `unable to process molecular profile with NOT operator (${this.profile.id || ''})`,
             );
         }
-
         // Filters out unwanted gene's info from expression
         const filteredParsedName = parsedName.filter(el => !el.entrezId);
 
-        // Parse expression into conditions and get variant objects from ids
-        return this._variants(
-            this._parse(filteredParsedName),
-        );
+        // Parse expression into conditions
+        this.conditions = this._parse(filteredParsedName);
+        // Replace Variant's ids with corresponding Variant's objects
+        this._variants();
+        // Disambiguate Variants' names with implicit 'or'
+        this._disambiguate();
+        return this;
     },
+    /* CIViC Evidence Item's Molecular Profile segment */
     profile: molecularProfile || {},
 });
 

--- a/test/civic.profile.test.js
+++ b/test/civic.profile.test.js
@@ -123,6 +123,21 @@ describe('MolecularProfile._variants()', () => {
             [{ id: 1, name: 'a1' }, { id: 3, name: 'a3' }],
         ]);
     });
+
+    test('tests cases that should throw an Error', () => {
+        const molecularProfile = {
+            id: 123,
+            variants: [
+                { id: 1, name: 'a1' },
+                { id: 2, name: 'a2' },
+            ],
+        };
+        expect(() => MolecularProfile(molecularProfile)._variants(
+            [[1, 2], [1, 3]],
+        )).toThrow(
+            `unable to process molecular profile with missing or misformatted variants (${molecularProfile.id || ''})`,
+        );
+    });
 });
 
 describe('MolecularProfile.process()', () => {

--- a/test/civic.profile.test.js
+++ b/test/civic.profile.test.js
@@ -108,22 +108,29 @@ describe('MolecularProfile._parse()', () => {
     );
 });
 
-describe('MolecularProfile.process()', () => {
-    test('variants ids replaced by objects & gene infos not interfering', () => {
+describe('MolecularProfile._variants()', () => {
+    test('variants ids replaced by objects', () => {
         expect(MolecularProfile({
-            parsedName: [
-                { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: '(' },
-                { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
-            ],
             variants: [
                 { id: 1, name: 'a1' },
                 { id: 2, name: 'a2' },
                 { id: 3, name: 'a3' },
             ],
-        }).process()).toEqual([
+        })._variants(
+            [[1, 2], [1, 3]],
+        )).toEqual([
             [{ id: 1, name: 'a1' }, { id: 2, name: 'a2' }],
             [{ id: 1, name: 'a1' }, { id: 3, name: 'a3' }],
         ]);
+    });
+});
+
+describe('MolecularProfile.process()', () => {
+    test('gene infos not interfering', () => {
+        expect(MolecularProfile({
+            parsedName: [{ entrezId: 9 }, { id: 1 }],
+            variants: [{ id: 1, name: 'a1' }],
+        }).process()).toEqual([[{ id: 1, name: 'a1' }]]);
     });
 
     test.each([

--- a/test/civic.profile.test.js
+++ b/test/civic.profile.test.js
@@ -48,87 +48,83 @@ describe('MolecularProfile._not()', () => {
     });
 });
 
-describe('MolecularProfile.process()', () => {
+describe('MolecularProfile._parse()', () => {
     test.each([
         [
-            { parsedName: [{ entrezId: 9 }, { id: 1 }, { text: 'AND' }, { entrezId: 9 }, { id: 2 }] },
+            [{ id: 1 }, { text: 'AND' }, { id: 2 }],
             [[1, 2]],
         ],
         [
-            { parsedName: [{ entrezId: 9 }, { id: 1 }, { text: 'OR' }, { entrezId: 9 }, { id: 2 }] },
+            [{ id: 1 }, { text: 'OR' }, { id: 2 }],
             [[1], [2]],
         ],
         [
-            {
-                parsedName: [
-                    { entrezId: 9 }, { id: 1 }, { text: 'AND' },
-                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
-                ],
-            },
+            [{ id: 1 }, { text: 'AND' }, { text: '(' }, { id: 2 }, { text: 'OR' }, { id: 3 }, { text: ')' }],
             [[1, 2], [1, 3]],
         ],
         [
-            {
-                parsedName: [
-                    { entrezId: 9 }, { id: 1 }, { text: 'OR' },
-                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'AND' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
-                ],
-            },
+            [{ id: 1 }, { text: 'OR' }, { text: '(' }, { id: 2 }, { text: 'AND' }, { id: 3 }, { text: ')' }],
             [[1], [2, 3]],
         ],
         [
-            {
-                parsedName: [
-                    { text: '(' }, { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { entrezId: 9 }, { id: 2 }, { text: ')' },
-                    { text: 'OR' }, { text: '(' }, { entrezId: 9 }, { id: 3 }, { text: 'AND' }, { entrezId: 9 }, { id: 4 }, { text: ')' },
-                ],
-            },
+            [
+                { text: '(' }, { id: 1 }, { text: 'AND' }, { id: 2 }, { text: ')' },
+                { text: 'OR' }, { text: '(' }, { id: 3 }, { text: 'AND' }, { id: 4 }, { text: ')' },
+            ],
             [[1, 2], [3, 4]],
         ],
         [
-            {
-                parsedName: [
-                    { text: '(' }, { entrezId: 9 }, { id: 1 }, { text: 'OR' }, { entrezId: 9 }, { id: 2 }, { text: ')' },
-                    { text: 'AND' }, { text: '(' }, { entrezId: 9 }, { id: 3 }, { text: 'OR' }, { entrezId: 9 }, { id: 4 }, { text: ')' },
-                ],
-            },
+            [
+                { text: '(' }, { id: 1 }, { text: 'OR' }, { id: 2 }, { text: ')' },
+                { text: 'AND' }, { text: '(' }, { id: 3 }, { text: 'OR' }, { id: 4 }, { text: ')' },
+            ],
             [[1, 3], [1, 4], [2, 3], [2, 4]],
         ],
         [
-            {
-                parsedName: [
-                    { entrezId: 9 }, { id: 1 }, { text: 'AND' },
-                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
-                    { text: 'AND' }, { text: '(' }, { entrezId: 9 }, { id: 4 }, { text: 'OR' }, { entrezId: 9 }, { id: 5 }, { text: ')' },
-                ],
-            },
+            [
+                { id: 1 }, { text: 'AND' }, { text: '(' }, { id: 2 }, { text: 'OR' }, { id: 3 }, { text: ')' },
+                { text: 'AND' }, { text: '(' }, { id: 4 }, { text: 'OR' }, { id: 5 }, { text: ')' },
+            ],
             [[1, 2, 4], [1, 2, 5], [1, 3, 4], [1, 3, 5]],
         ],
         [
-            {
-                parsedName: [
-                    { entrezId: 9 }, { id: 1 }, { text: 'OR' },
-                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'AND' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
-                    { text: 'OR' }, { text: '(' }, { entrezId: 9 }, { id: 4 }, { text: 'AND' }, { entrezId: 9 }, { id: 5 }, { text: ')' },
-                ],
-            },
+            [
+                { id: 1 }, { text: 'OR' }, { text: '(' }, { id: 2 }, { text: 'AND' }, { id: 3 }, { text: ')' },
+                { text: 'OR' }, { text: '(' }, { id: 4 }, { text: 'AND' }, { id: 5 }, { text: ')' },
+            ],
             [[1], [2, 3], [4, 5]],
         ],
         [
-            {
-                parsedName: [
-                    { entrezId: 9 }, { id: 1 }, { text: 'AND' },
-                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'AND' },
-                    { text: '(' }, { entrezId: 9 }, { id: 3 }, { text: 'OR' }, { id: 4 }, { text: ')' }, { text: ')' },
-                ],
-            },
+            [
+                { id: 1 }, { text: 'AND' }, { text: '(' }, { id: 2 }, { text: 'AND' },
+                { text: '(' }, { id: 3 }, { text: 'OR' }, { id: 4 }, { text: ')' }, { text: ')' },
+            ],
             [[1, 2, 3], [1, 2, 4]],
         ],
     ])(
-        'testing some Molecular Profiles expressions', (molecularProfile, expected) => {
-            expect(MolecularProfile(molecularProfile).process()).toEqual(expected);
+        'testing some Molecular Profiles expressions', (block, expected) => {
+            expect(MolecularProfile()._parse(block)).toEqual(expected);
         },
     );
+});
+
+describe('MolecularProfile.process()', () => {
+    test('variants ids replaced by objects & gene infos not interfering', () => {
+        expect(MolecularProfile({
+            parsedName: [
+                { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: '(' },
+                { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+            ],
+            variants: [
+                { id: 1, name: 'a1' },
+                { id: 2, name: 'a2' },
+                { id: 3, name: 'a3' },
+            ],
+        }).process()).toEqual([
+            [{ id: 1, name: 'a1' }, { id: 2, name: 'a2' }],
+            [{ id: 1, name: 'a1' }, { id: 3, name: 'a3' }],
+        ]);
+    });
 
     test.each([
         [{}],

--- a/test/civic.profile.test.js
+++ b/test/civic.profile.test.js
@@ -1,0 +1,164 @@
+const { MolecularProfile } = require('../src/civic/profile');
+
+
+describe('MolecularProfile._compile()', () => {
+    test.each([
+        [[['A', 'B']], 'AND', [['C', 'D']], [['A', 'B', 'C', 'D']]],
+        [[['A', 'B']], 'AND', [['C', 'D'], ['E', 'F']], [['A', 'B', 'C', 'D'], ['A', 'B', 'E', 'F']]],
+        [[['A', 'B'], ['C', 'D']], 'AND', [['E', 'F']], [['A', 'B', 'E', 'F'], ['C', 'D', 'E', 'F']]],
+        [[['A', 'B']], 'OR', [['C', 'D']], [['A', 'B'], ['C', 'D']]],
+        [[['A', 'B']], 'OR', [['C', 'D'], ['E', 'F']], [['A', 'B'], ['C', 'D'], ['E', 'F']]],
+        [[['A', 'B'], ['C', 'D']], 'OR', [['E', 'F']], [['A', 'B'], ['C', 'D'], ['E', 'F']]],
+    ])(
+        'testing some conditions\' combinations', (arr, op, part, expected) => {
+            expect(MolecularProfile()._compile({ arr, op, part })).toEqual(expected);
+        },
+    );
+});
+
+describe('MolecularProfile._end()', () => {
+    const block = [
+        { id: 1 }, { text: 'AND' },
+        { text: '(' }, { id: 2 }, { text: 'OR' }, { id: 3 }, { text: ')' }, { text: 'AND' },
+        { text: '(' }, { id: 4 }, { text: 'OR' },
+        { text: '(' }, { id: 5 }, { text: 'AND' }, { id: 6 }, { text: ')' }, { text: ')' },
+    ];
+
+    test.each([
+        [2, 0, 4],
+        [4, 4, 8],
+        [6, 4, 6],
+    ])(
+        'testing index and offset combinations: i=%s, offset=%s', (i, offset, expected) => {
+            expect(MolecularProfile()._end({ block, i, offset })).toEqual(expected);
+        },
+    );
+});
+
+describe('MolecularProfile._not()', () => {
+    test('check for presence of NOT operator in expression', () => {
+        expect(MolecularProfile()._not([
+            { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: 'NOT' }, { text: '(' },
+            { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+        ])).toBe(true);
+        expect(MolecularProfile()._not([
+            { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: '(' }, { entrezId: 9 },
+            { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+        ])).toBe(false);
+    });
+});
+
+describe('MolecularProfile.process()', () => {
+    test.each([
+        [
+            { parsedName: [{ entrezId: 9 }, { id: 1 }, { text: 'AND' }, { entrezId: 9 }, { id: 2 }] },
+            [[1, 2]],
+        ],
+        [
+            { parsedName: [{ entrezId: 9 }, { id: 1 }, { text: 'OR' }, { entrezId: 9 }, { id: 2 }] },
+            [[1], [2]],
+        ],
+        [
+            {
+                parsedName: [
+                    { entrezId: 9 }, { id: 1 }, { text: 'AND' },
+                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+                ],
+            },
+            [[1, 2], [1, 3]],
+        ],
+        [
+            {
+                parsedName: [
+                    { entrezId: 9 }, { id: 1 }, { text: 'OR' },
+                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'AND' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+                ],
+            },
+            [[1], [2, 3]],
+        ],
+        [
+            {
+                parsedName: [
+                    { text: '(' }, { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { entrezId: 9 }, { id: 2 }, { text: ')' },
+                    { text: 'OR' }, { text: '(' }, { entrezId: 9 }, { id: 3 }, { text: 'AND' }, { entrezId: 9 }, { id: 4 }, { text: ')' },
+                ],
+            },
+            [[1, 2], [3, 4]],
+        ],
+        [
+            {
+                parsedName: [
+                    { text: '(' }, { entrezId: 9 }, { id: 1 }, { text: 'OR' }, { entrezId: 9 }, { id: 2 }, { text: ')' },
+                    { text: 'AND' }, { text: '(' }, { entrezId: 9 }, { id: 3 }, { text: 'OR' }, { entrezId: 9 }, { id: 4 }, { text: ')' },
+                ],
+            },
+            [[1, 3], [1, 4], [2, 3], [2, 4]],
+        ],
+        [
+            {
+                parsedName: [
+                    { entrezId: 9 }, { id: 1 }, { text: 'AND' },
+                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+                    { text: 'AND' }, { text: '(' }, { entrezId: 9 }, { id: 4 }, { text: 'OR' }, { entrezId: 9 }, { id: 5 }, { text: ')' },
+                ],
+            },
+            [[1, 2, 4], [1, 2, 5], [1, 3, 4], [1, 3, 5]],
+        ],
+        [
+            {
+                parsedName: [
+                    { entrezId: 9 }, { id: 1 }, { text: 'OR' },
+                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'AND' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+                    { text: 'OR' }, { text: '(' }, { entrezId: 9 }, { id: 4 }, { text: 'AND' }, { entrezId: 9 }, { id: 5 }, { text: ')' },
+                ],
+            },
+            [[1], [2, 3], [4, 5]],
+        ],
+        [
+            {
+                parsedName: [
+                    { entrezId: 9 }, { id: 1 }, { text: 'AND' },
+                    { text: '(' }, { entrezId: 9 }, { id: 2 }, { text: 'AND' },
+                    { text: '(' }, { entrezId: 9 }, { id: 3 }, { text: 'OR' }, { id: 4 }, { text: ')' }, { text: ')' },
+                ],
+            },
+            [[1, 2, 3], [1, 2, 4]],
+        ],
+    ])(
+        'testing some Molecular Profiles expressions', (molecularProfile, expected) => {
+            expect(MolecularProfile(molecularProfile).process()).toEqual(expected);
+        },
+    );
+
+    test.each([
+        [{}],
+        [{ parsedName: '' }],
+        [{ parsedName: [] }],
+        [{ parsedName: [''] }],
+    ])(
+        'tests cases that should throw an Error', (molecularProfile) => {
+            expect(() => MolecularProfile(molecularProfile).process()).toThrow(
+                `unable to process molecular profile with missing or misformatted parsedName (${molecularProfile.id || ''})`,
+            );
+        },
+    );
+
+    test('not providing a molecularProfile argument should also throw an Error', () => {
+        expect(() => MolecularProfile().process()).toThrow(
+            'unable to process molecular profile with missing or misformatted parsedName ()',
+        );
+    });
+
+    test('test case that should throw a NotImplementedError', () => {
+        const molecularProfile = {
+            id: 1,
+            parsedName: [
+                { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: 'NOT' }, { text: '(' },
+                { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+            ],
+        };
+        expect(() => MolecularProfile(molecularProfile).process()).toThrow(
+            `unable to process molecular profile with NOT operator (${molecularProfile.id || ''})`,
+        );
+    });
+});


### PR DESCRIPTION
Add complexe molecular support for Civic loader.

@cgrisdale , are these changes (https://github.com/bcgsc/pori_graphkb_loader/pull/117/commits/6c22c857622e978322220c58fd600045b99ead31) to evidenceType and relevance handling ok? 
