### PR TITLE
Update to CIViC API v2.4

### DIFF
--- a/src/civic/evidenceItems.graphql
+++ b/src/civic/evidenceItems.graphql
@@ -72,15 +72,21 @@ query evidenceItems(
         id
         name
         parsedName {
-          ... on Gene { entrezId }
+          __typename
           ... on MolecularProfileTextSegment { text }
           ... on Variant { id }
         }
         rawName
         variants {
-          gene {
-            entrezId
-            name
+          feature {
+            featureInstance {
+              __typename
+              ... on Factor { id }
+              ... on Gene {
+                entrezId
+                name
+              }
+            }
           }
           id
           name

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -229,7 +229,7 @@ const processEvidenceRecord = async (opt) => {
         // TODO: Deal with __typename === 'Factor'
         // No actual case as April 22nd, 2024
         throw new NotImplementedError(
-            `unable to process variant's feature of type Factor`,
+            'unable to process variant\'s feature of type Factor',
         );
     }
 

--- a/src/civic/index.js
+++ b/src/civic/index.js
@@ -26,8 +26,6 @@ const { EvidenceItem: evidenceSpec } = require('./specs.json');
 
 class NotImplementedError extends ErrorMixin { }
 
-const ajv = new Ajv();
-
 const BASE_URL = 'https://civicdb.org/api/graphql';
 
 /**
@@ -50,6 +48,8 @@ const VOCAB = {
 
 const EVIDENCE_LEVEL_CACHE = {}; // avoid unecessary requests by caching the evidence levels
 
+// Spec compiler
+const ajv = new Ajv();
 const validateEvidenceSpec = ajv.compile(evidenceSpec);
 
 
@@ -213,11 +213,28 @@ const processEvidenceRecord = async (opt) => {
         conn, rawRecord, sources, variantsCache, oneToOne = false,
     } = opt;
 
-    const [level, relevance, [feature]] = await Promise.all([
+    // Relevance & EvidenceLevel
+    const [level, relevance] = await Promise.all([
         getEvidenceLevel(opt),
         getRelevance(opt),
-        _entrezGene.fetchAndLoadByIds(conn, [rawRecord.variant.gene.entrezId]),
     ]);
+
+    // Variant's Feature
+    let feature;
+    const civicFeature = rawRecord.variant.feature.featureInstance;
+
+    if (civicFeature.__typename === 'Gene') {
+        [feature] = await _entrezGene.fetchAndLoadByIds(conn, [civicFeature.entrezId]);
+    } else if (civicFeature.__typename === 'Factor') {
+        // TODO: Deal with __typename === 'Factor'
+        // No actual case as April 22nd, 2024
+        throw new NotImplementedError(
+            `unable to process variant's feature of type Factor`,
+        );
+    }
+
+
+    // Variant
     let variants;
 
     if (variantsCache.records[rawRecord.variant.id]) {
@@ -235,7 +252,6 @@ const processEvidenceRecord = async (opt) => {
             throw err;
         }
     }
-
 
     // get the disease by doid
     let disease;
@@ -382,6 +398,7 @@ const processEvidenceRecord = async (opt) => {
         // update the existing record
         return conn.updateRecord('Statement', rid(original), content);
     }
+
     // create a new record
     return conn.addRecord({
         content,
@@ -486,6 +503,7 @@ const downloadEvidenceRecords = async (url, trustedCurators) => {
         }
         records.push(record);
     }
+    logger.info(`${records.length}/${evidenceItems.length} evidenceItem records successfully validated with the specs`);
     return { counts, errorList, records };
 };
 
@@ -604,7 +622,7 @@ const upload = async ({
             record.conditions = Mp.process().conditions;
         } catch (err) {
             logger.error(`evidence (${record.id}) ${err}`);
-            counts.skip += 1;
+            counts.skip++;
             continue;
         }
 

--- a/src/civic/profile.js
+++ b/src/civic/profile.js
@@ -226,8 +226,8 @@ const MolecularProfile = (molecularProfile) => ({
                 `unable to process molecular profile with NOT operator (${this.profile.id || ''})`,
             );
         }
-        // Filters out unwanted gene's info from expression
-        const filteredParsedName = parsedName.filter(el => !el.entrezId);
+        // Filters out unwanted Feature info from expression
+        const filteredParsedName = parsedName.filter(el => el.__typename !== 'Feature');
 
         // Parse expression into conditions
         this.conditions = this._parse(filteredParsedName);

--- a/src/civic/specs.json
+++ b/src/civic/specs.json
@@ -84,32 +84,21 @@
                     },
                     "parsedName": {
                         "items": {
-                            "anyOf": [
-                                {
-                                    "properties": {
-                                        "entrezId": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "type": "object"
+                            "properties": {
+                                "__typename": {
+                                    "type": "string"
                                 },
-                                {
-                                    "properties": {
-                                        "id": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "type": "object"
+                                "id": {
+                                    "type": "number"
                                 },
-                                {
-                                    "properties": {
-                                        "text": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object"
+                                "text": {
+                                    "type": "string"
                                 }
-                            ]
+                            },
+                            "required":[
+                                "__typename"
+                            ],
+                            "type": "object"
                         },
                         "type": "array"
                     },
@@ -122,39 +111,45 @@
                     "variants": {
                         "items": {
                             "properties": {
-                                "gene": {
+                                "feature": {
                                     "properties": {
-                                        "entrezId": {
-                                            "type": [
-                                                "null",
-                                                "number"
-                                            ]
-                                        },
-                                        "name": {
-                                            "type": [
-                                                "null",
-                                                "string"
-                                            ]
+                                        "featureInstance": {
+                                            "properties": {
+                                                "__typename": {
+                                                    "type": "string"
+                                                },
+                                                "entrezId": {
+                                                    "type": "number"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required":[
+                                                "__typename",
+                                                "entrezId",
+                                                "name"
+                                            ],
+                                            "type": "object"
                                         }
                                     },
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ]
+                                    "required": [
+                                        "featureInstance"
+                                    ],
+                                    "type": "object"
                                 },
                                 "id": {
-                                    "type": [
-                                        "null",
-                                        "number"
-                                    ]
+                                    "type": "number"
                                 },
                                 "name": {
-                                    "type": [
-                                        "null",
-                                        "string"
-                                    ]
+                                    "type": "string"
                                 }
                             },
+                            "required": [
+                                "feature",
+                                "id",
+                                "name"
+                            ],
                             "type": [
                                 "null",
                                 "object"
@@ -166,10 +161,14 @@
                         ]
                     }
                 },
-                "type": [
-                    "null",
-                    "object"
-                ]
+                "required": [
+                    "id",
+                    "name",
+                    "parsedName",
+                    "rawName",
+                    "variants"
+                ],
+                "type": "object"
             },
             "phenotypes": {
                 "items": {
@@ -317,9 +316,22 @@
                 ]
             }
         },
-        "type": [
-            "null",
-            "object"
-        ]
+        "required":[
+            "description",
+            "disease",
+            "evidenceDirection",
+            "evidenceLevel",
+            "evidenceRating",
+            "evidenceType",
+            "id",
+            "molecularProfile",
+            "phenotypes",
+            "significance",
+            "source",
+            "status",
+            "therapies",
+            "therapyInteractionType"
+        ],
+        "type": "object"
     }
 }

--- a/src/civic/variant.js
+++ b/src/civic/variant.js
@@ -341,7 +341,7 @@ const processVariantRecord = async (conn, civicVariantRecord, feature) => {
         // TODO: Deal with __typename === 'Factor'
         // No actual case as April 22nd, 2024
         throw new NotImplementedError(
-            `unable to process variant's feature of type Factor`,
+            'unable to process variant\'s feature of type Factor',
         );
     }
 

--- a/src/civic/variant.js
+++ b/src/civic/variant.js
@@ -1,15 +1,11 @@
 const kbParser = require('@bcgsc-pori/graphkb-parser');
-
-const { error: { ParsingError } } = kbParser;
-const {
-    rid,
-} = require('../graphkb');
+const { rid } = require('../graphkb');
 const _entrezGene = require('../entrez/gene');
 const _snp = require('../entrez/snp');
+const { civic: SOURCE_DEFN } = require('../sources');
 
-const {
-    civic: SOURCE_DEFN,
-} = require('../sources');
+const { error: { ErrorMixin, ParsingError } } = kbParser;
+class NotImplementedError extends ErrorMixin { }
 
 
 // based on discussion with cam here: https://www.bcgsc.ca/jira/browse/KBDEV-844
@@ -229,8 +225,8 @@ const normalizeVariantRecord = ({
 };
 
 /**
- * Given some normalized variant record from CIViC load into graphkb, create links and
- * return the record
+ * Given some normalized variant record from CIViC,
+ * load into graphkb, create links and return the record
  *
  * @param {ApiConnection} conn the connection to GraphKB
  * @param {Object} normalizedVariant the normalized variant record
@@ -328,11 +324,30 @@ const uploadNormalizedVariant = async (conn, normalizedVariant, feature) => {
 
 /**
  * Given some variant record and a feature, process the variant and return a GraphKB equivalent
+ *
+ * @param {ApiConnection} conn the connection to GraphKB
+ * @param {Object} civicVariantRecord the raw variant record from CIViC
+ * @param {Object} feature the gene feature already grabbed from GraphKB
  */
 const processVariantRecord = async (conn, civicVariantRecord, feature) => {
+    const featureInstance = civicVariantRecord.feature.featureInstance;
+    let entrezId,
+        entrezName;
+
+    if (featureInstance.__typename === 'Gene') {
+        entrezId = featureInstance.entrezId;
+        entrezName = featureInstance.name;
+    } else if (featureInstance.__typename === 'Factor') {
+        // TODO: Deal with __typename === 'Factor'
+        // No actual case as April 22nd, 2024
+        throw new NotImplementedError(
+            `unable to process variant's feature of type Factor`,
+        );
+    }
+
     const variants = normalizeVariantRecord({
-        entrezId: civicVariantRecord.gene.entrezId,
-        entrezName: civicVariantRecord.gene.name,
+        entrezId,
+        entrezName,
         name: civicVariantRecord.name,
     });
 

--- a/test/civic.profile.test.js
+++ b/test/civic.profile.test.js
@@ -70,12 +70,12 @@ describe('MolecularProfile._end()', () => {
 describe('MolecularProfile._not()', () => {
     test('check for presence of NOT operator in expression', () => {
         expect(MolecularProfile()._not([
-            { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: 'NOT' }, { text: '(' },
-            { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+            { __typename: 'Feature' }, { id: 1 }, { text: 'AND' }, { text: 'NOT' }, { text: '(' },
+            { __typename: 'Feature' }, { id: 2 }, { text: 'OR' }, { __typename: 'Feature' }, { id: 3 }, { text: ')' },
         ])).toBe(true);
         expect(MolecularProfile()._not([
-            { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: '(' }, { entrezId: 9 },
-            { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+            { __typename: 'Feature' }, { id: 1 }, { text: 'AND' }, { text: '(' }, { __typename: 'Feature' },
+            { id: 2 }, { text: 'OR' }, { __typename: 'Feature' }, { id: 3 }, { text: ')' },
         ])).toBe(false);
     });
 });
@@ -187,7 +187,7 @@ describe('MolecularProfile._variants()', () => {
 describe('MolecularProfile.process()', () => {
     test('gene infos not interfering', () => {
         expect(MolecularProfile({
-            parsedName: [{ entrezId: 9 }, { id: 1 }],
+            parsedName: [{ __typename: 'Feature' }, { id: 1 }],
             variants: [{ id: 1, name: 'a1' }],
         }).process().conditions).toEqual([[{ id: 1, name: 'a1' }]]);
     });
@@ -215,8 +215,8 @@ describe('MolecularProfile.process()', () => {
         const molecularProfile = {
             id: 1,
             parsedName: [
-                { entrezId: 9 }, { id: 1 }, { text: 'AND' }, { text: 'NOT' }, { text: '(' },
-                { entrezId: 9 }, { id: 2 }, { text: 'OR' }, { entrezId: 9 }, { id: 3 }, { text: ')' },
+                { __typename: 'Feature' }, { id: 1 }, { text: 'AND' }, { text: 'NOT' }, { text: '(' },
+                { __typename: 'Feature' }, { id: 2 }, { text: 'OR' }, { __typename: 'Feature' }, { id: 3 }, { text: ')' },
             ],
         };
         expect(() => MolecularProfile(molecularProfile).process()).toThrow(


### PR DESCRIPTION
New CIViC API v2.4 is making breaking changes to schema. This is why the cron was failing.

Now a variant get assigned a feature instead of a gene, and a feature can be either of type GENE or FACTOR.

As of yesterday, there is no feature of type FACTOR in CIViC yet, so this option is not implemented since we have no data to test it.

Also in this PR are changes to the spec.json file so it will actually fail prematurely if records aren't complying.