### PR TITLE
Feature/kbdev 1240 update entrez gene records

### DIFF
--- a/src/entrez/gene.js
+++ b/src/entrez/gene.js
@@ -70,7 +70,7 @@ const fetchAndLoadGeneByIds = async (api, idListIn, opt = {}) => {
             target: 'Feature',
             upsert,
         },
-    )
+    );
 };
 
 /**

--- a/src/entrez/gene.js
+++ b/src/entrez/gene.js
@@ -49,19 +49,29 @@ const parseRecord = (record) => {
  *
  * @param {ApiConnection} api connection to GraphKB
  * @param {Array.<string>} idList list of gene IDs
+ * @param {object} opt
+ * @param {boolean} opt.fetchFirst override util.uploadRecord() fetchFirst
+ * @param {boolean} opt.upsert override util.uploadRecord() upsert
  */
-const fetchAndLoadGeneByIds = async (api, idListIn) => util.fetchAndLoadByIds(
-    api,
-    idListIn,
-    {
-        MAX_CONSEC,
-        cache: CACHE,
-        dbName: DB_NAME,
-        parser: parseRecord,
-        sourceDefn: SOURCE_DEFN,
-        target: 'Feature',
-    },
-);
+const fetchAndLoadGeneByIds = async (api, idListIn, opt = {}) => {
+    // For record update, set fetchFirst to false & upsert to true.
+    const { fetchFirst, upsert } = opt;
+
+    return util.fetchAndLoadByIds(
+        api,
+        idListIn,
+        {
+            MAX_CONSEC,
+            cache: CACHE,
+            dbName: DB_NAME,
+            fetchFirst,
+            parser: parseRecord,
+            sourceDefn: SOURCE_DEFN,
+            target: 'Feature',
+            upsert,
+        },
+    )
+};
 
 /**
  * Given a gene symbol, search the genes and upload the resulting records to graphkb

--- a/src/entrez/util.js
+++ b/src/entrez/util.js
@@ -267,7 +267,14 @@ const preLoadCache = async (api, { sourceDefn, cache, target }) => {
  * @param {boolean} opt.upsert override uploadRecord() upsert
  */
 const fetchAndLoadByIds = async (api, idListIn, {
-    dbName, fetchFirst, parser, cache, MAX_CONSEC = 100, target, sourceDefn, upsert
+    dbName,
+    fetchFirst,
+    parser,
+    cache,
+    MAX_CONSEC = 100,
+    target,
+    sourceDefn,
+    upsert,
 }) => {
     const records = await fetchByIdList(
         idListIn,

--- a/src/entrez/util.js
+++ b/src/entrez/util.js
@@ -138,6 +138,7 @@ const fetchRecord = async (api, {
  * @param {boolean} opt.fetchFirst attempt to get the record by source Id before uploading it
  * @param {string} opt.target
  * @param {object} opt.sourceDefn
+ * @param {boolean} opt.upsert update the record if already exists
  * @param {function} opt.createDisplayName
  */
 const uploadRecord = async (api, content, opt = {}) => {
@@ -257,14 +258,16 @@ const preLoadCache = async (api, { sourceDefn, cache, target }) => {
  * @param {Array.<string>} idListIn list of pubmed IDs
  * @param {Object} opt
  * @param {string} opt.dbName name of the entrez db to pull from ex. gene
+ * @param {boolean} opt.fetchFirst override uploadRecord() fetchFirst
  * @param {function} opt.parser function to convert records from the api to the graphkb format
  * @param {object} opt.cache
  * @param {number} opt.MAX_CONSEC maximum consecutive records to upload at once
  * @param {string} opt.target the graphkb api target to upload to
  * @param {object} opt.sourceDefn the object with the source information
+ * @param {boolean} opt.upsert override uploadRecord() upsert
  */
 const fetchAndLoadByIds = async (api, idListIn, {
-    dbName, parser, cache, MAX_CONSEC = 100, target, sourceDefn,
+    dbName, fetchFirst, parser, cache, MAX_CONSEC = 100, target, sourceDefn, upsert
 }) => {
     const records = await fetchByIdList(
         idListIn,
@@ -281,8 +284,10 @@ const fetchAndLoadByIds = async (api, idListIn, {
         const newRecords = await Promise.all(current.map(
             async record => uploadRecord(api, record, {
                 cache,
+                fetchFirst,
                 sourceDefn,
                 target,
+                upsert,
             }),
         ));
         result.push(...newRecords);

--- a/src/util.js
+++ b/src/util.js
@@ -234,6 +234,7 @@ module.exports = {
     hashStringToId,
     loadDelimToJson,
     loadXmlToJson,
+    logger,
     parseXmlToJson,
     request,
     requestWithRetry,


### PR DESCRIPTION
In order to enable Entrez Gene records update, fetchFirst and upsert arguments need to be passed along the way from gene.fetchAndLoadGeneByIds() to util.uploadRecord().