### PR TITLE
Bugfix/kbdev 993 handle moa loader errors

### DIFF
--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -547,19 +547,6 @@ const parseRelevance = (moaRecord) => {
     return relevance;
 };
 
-const removeRecords = async (conn, records) => {
-    if (records.length && records.length > 0) {
-        for (const record of records) {
-            try {
-                await conn.deleteRecord('Statement', record['@rid']);
-                logger.info(`Removing Statement ${record['@rid']} that are out of date`);
-            } catch (err) {
-                logger.warn(`${err}`);
-            }
-        }
-    }
-};
-
 const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) => {
     const source = await conn.addSource(SOURCE_DEFN);
     const records = await requestWithRetry({ json: true, method: 'GET', uri: url });
@@ -578,19 +565,18 @@ const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) =>
             }
             // work around to match with gkb records
             if (record.therapy_name) {
-                if (record.therapy_name.includes("Amivantamab-vmjw")) {
-                    record.therapy_name = record.therapy_name.replace("Amivantamab-vmjw","amivantamab");
-                } else if (record.therapy_name === "KU0058684") {
-                    record.therapy_name = "olaparib";
-                } else if (record.therapy_name === "Tovorafenib") {
-                    record.therapy_name = "pan-raf kinase inhibitor tak-580";
+                if (record.therapy_name.includes('Amivantamab-vmjw')) {
+                    record.therapy_name = record.therapy_name.replace('Amivantamab-vmjw', 'amivantamab');
+                } else if (record.therapy_name === 'KU0058684') {
+                    record.therapy_name = 'olaparib';
+                } else if (record.therapy_name === 'Tovorafenib') {
+                    record.therapy_name = 'pan-raf kinase inhibitor tak-580';
                 }
             }
             checkSpec(validateMoaRecord, record);
-            const key = `${record.assertion_id}`;
             const relevance = parseRelevance(record);
 
-            const updatedRecords = (await loadRecord(conn, record, source, relevance)).map(r => r['@rid']);
+            await loadRecord(conn, record, source, relevance);
 
             counts.success++;
         } catch (err) {

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -260,22 +260,23 @@ const loadVariant = async (conn, moaVariant) => {
             filters: {
                 AND: [
                     { source: { filters: { name: 'cosmic' }, target: 'Source' } },
-                    { sourceId: moaVariant.cosmic_signature},
+                    { sourceId: moaVariant.cosmic_signature },
                 ],
             },
             target: 'Signature',
         });
         const variantType = await conn.getVocabularyTerm('signature present');
-        try{
-           const record = await conn.getUniqueRecordBy({
-                filters: { AND: [{ reference1: rid(signature[0])}, { type: rid(variantType) }] },
+
+        try {
+            const record = await conn.getUniqueRecordBy({
+                filters: { AND: [{ reference1: rid(signature[0]) }, { type: rid(variantType) }] },
                 target: 'CategoryVariant',
             });
             return await conn.updateRecord('CategoryVariant', record['@rid'], {
-                displayName: `${signature[0].name.toUpperCase()} signature present`
+                displayName: `${signature[0].name.toUpperCase()} signature present`,
             });
-        } catch(err) {
-            return await conn.addVariant({
+        } catch (err) {
+            return conn.addVariant({
                 content: {
                     displayName: `${signature[0].name.toUpperCase()} signature present`,
                     reference1: rid(signature[0]),
@@ -370,7 +371,7 @@ const loadRecord = async (conn, moaRecord, moaSource, relevanceTerms) => {
             } else if (['FDA', 'Guideline'].includes(sourceRecord.source_type)) {
                 try {
                     const record = await conn.getUniqueRecordBy({
-                        filters: { AND: [{ source: rid(moaSource)}, { sourceId: sourceRecord.source_id }, {name: `${sourceRecord.source_type}-${sourceRecord.source_id}`}] },
+                        filters: { AND: [{ source: rid(moaSource) }, { sourceId: sourceRecord.source_id }, { name: `${sourceRecord.source_type}-${sourceRecord.source_id}` }] },
                         target: 'CuratedContent',
                     });
                     articles.push(await conn.updateRecord('CuratedContent', record['@rid'], {
@@ -378,7 +379,7 @@ const loadRecord = async (conn, moaRecord, moaSource, relevanceTerms) => {
                         displayName: `${SOURCE_DEFN.displayName} ${sourceRecord.source_type}-${sourceRecord.source_id}`,
                         url: sourceRecord.url,
                     }));
-                } catch(err) {
+                } catch (err) {
                     articles.push(await conn.addRecord({
                         content: {
                             citation: sourceRecord.citation,
@@ -571,9 +572,10 @@ const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) =>
         try {
             logger.info(`loading: ${rawRecord.assertion_id} / ${records.length}`);
             const record = fixStringNulls(rawRecord);
+
             // handle empty space in url
-            if (record.sources[0].url && record.sources[0].url.includes(' ')){
-                record.sources[0].url = record.sources[0].url.replace(/\s/g,'');
+            if (record.sources[0].url && record.sources[0].url.includes(' ')) {
+                record.sources[0].url = record.sources[0].url.replace(/\s/g, '');
             }
             checkSpec(validateMoaRecord, record);
             const key = `${record.assertion_id}`;

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -547,7 +547,7 @@ const parseRelevance = (moaRecord) => {
 const removeRecords = async (conn, records) => {
     if (records.length && records.length > 0) {
         for (const record of records) {
-            try{
+            try {
                 await conn.deleteRecord('Statement', record['@rid']);
                 logger.info(`Removing Statement ${record['@rid']} that are out of date`);
             } catch (err) {
@@ -591,9 +591,6 @@ const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) =>
             logger.info(`loading: ${rawRecord.assertion_id} / ${records.length}`);
             const record = fixStringNulls(rawRecord);
 
-            if (record.assertion_id === 258){
-                logger.info(`loading: ${rawRecord.assertion_id}`);
-            }
             // handle empty space in url
             if (record.sources[0].url && record.sources[0].url.includes(' ')) {
                 record.sources[0].url = record.sources[0].url.replace(/\s/g, '');

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -256,11 +256,12 @@ const loadVariant = async (conn, moaVariant) => {
             });
         }
     } else if (moaVariant.feature_type === 'mutational_signature') {
-        const signature = await conn.getRecords({
+        const signature = await conn.getUniqueRecordBy({
             filters: {
                 AND: [
                     { source: { filters: { name: 'cosmic' }, target: 'Source' } },
                     { sourceId: moaVariant.cosmic_signature },
+                    { sourceIdVersion: '3'},
                 ],
             },
             target: 'Signature',
@@ -269,17 +270,17 @@ const loadVariant = async (conn, moaVariant) => {
 
         try {
             const record = await conn.getUniqueRecordBy({
-                filters: { AND: [{ reference1: rid(signature[0]) }, { type: rid(variantType) }] },
+                filters: { AND: [{ reference1: rid(signature) }, { type: rid(variantType) }] },
                 target: 'CategoryVariant',
             });
             return await conn.updateRecord('CategoryVariant', record['@rid'], {
-                displayName: `${signature[0].name.toUpperCase()} signature present`,
+                displayName: `${signature.name.toUpperCase()} signature present`,
             });
         } catch (err) {
             return conn.addVariant({
                 content: {
-                    displayName: `${signature[0].name.toUpperCase()} signature present`,
-                    reference1: rid(signature[0]),
+                    displayName: `${signature.name.toUpperCase()} signature present`,
+                    reference1: rid(signature),
                     type: rid(variantType),
                 },
                 existsOk: true,

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -265,7 +265,7 @@ const loadVariant = async (conn, moaVariant) => {
             },
             target: 'Signature',
         });
-        const variantType = await conn.getVocabularyTerm('signature present');
+        const variantType = await conn.getVocabularyTerm('high signature');
 
         try {
             const record = await conn.getUniqueRecordBy({

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -258,6 +258,7 @@ const loadVariant = async (conn, moaVariant) => {
     } else if (moaVariant.feature_type === 'mutational_signature') {
         // Cosmic signature
         let signature = {};
+
         try {
             signature = await conn.getUniqueRecordBy({
                 target: 'Signature',
@@ -274,15 +275,14 @@ const loadVariant = async (conn, moaVariant) => {
                     ],
                 },
             });
-        } catch(err) {
+        } catch (err) {
             // Enforcing usage of v3 Cosmic signatures
             throw Error(`Missing Cosmic signature ${moaVariant.cosmic_signature}`);
         }
 
         // 'high signature' variant type (prefered over 'signature present')
         const variantType = await conn.getVocabularyTerm('high signature');
-        
-        
+
         // Corresponding 'high signature' CategoryVariant
         try {
             return await conn.addVariant({

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -261,7 +261,7 @@ const loadVariant = async (conn, moaVariant) => {
                 AND: [
                     { source: { filters: { name: 'cosmic' }, target: 'Source' } },
                     { sourceId: moaVariant.cosmic_signature },
-                    { sourceIdVersion: '3'},
+                    { sourceIdVersion: '3' },
                 ],
             },
             target: 'Signature',

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -544,6 +544,18 @@ const parseRelevance = (moaRecord) => {
     return relevance;
 };
 
+const removeRecords = async (conn, records) => {
+    if (records.length && records.length > 0) {
+        for (const record of records) {
+            try{
+                await conn.deleteRecord('Statement', record['@rid']);
+                logger.info(`Removing Statement ${record['@rid']} that are out of date`);
+            } catch (err) {
+                logger.warn(`${err}`);
+            }
+        }
+    }
+};
 
 const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) => {
     const source = await conn.addSource(SOURCE_DEFN);
@@ -559,6 +571,12 @@ const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) =>
 
     const existing = {};
 
+    const newIds = records.map(record => record.assertion_id);
+    let toRemove = existingRecords.filter(
+        record => !newIds.includes(parseInt(record.sourceId, 10)),
+    );
+    await removeRecords(conn, toRemove);
+
     for (const record of existingRecords) {
         const key = record.sourceId;
 
@@ -573,41 +591,31 @@ const upload = async ({ conn, url = 'https://moalmanac.org/api/assertions' }) =>
             logger.info(`loading: ${rawRecord.assertion_id} / ${records.length}`);
             const record = fixStringNulls(rawRecord);
 
+            if (record.assertion_id === 258){
+                logger.info(`loading: ${rawRecord.assertion_id}`);
+            }
             // handle empty space in url
             if (record.sources[0].url && record.sources[0].url.includes(' ')) {
                 record.sources[0].url = record.sources[0].url.replace(/\s/g, '');
             }
             checkSpec(validateMoaRecord, record);
             const key = `${record.assertion_id}`;
-            const lastUpdate = new Date(record.last_updated).getTime();
             const relevance = parseRelevance(record);
 
-            // do we have the expected number of GraphKB records for this MOA assertion
-            if (existing[key] && existing[key].length === relevance.length) {
-                // check the last update date of the assertion against the timestamp in GraphKB
-                if (existing[key].every(r => lastUpdate <= r.updatedAt)) {
-                    logger.debug('Skip. Current record exists and does not need updating');
-                    counts.skipped++;
-                    continue;
-                }
-            }
             const updatedRecords = (await loadRecord(conn, record, source, relevance)).map(r => r['@rid']);
 
             if (existing[key]) {
-                const toRemove = existing[key].map(r => r['@rid']).filter(r => !updatedRecords.includes(r));
-
-                if (toRemove.length) {
-                    logger.warn(`Removing ${toRemove.length} records that are out of date`);
-
-                    for (const recordId of toRemove) {
-                        await conn.deleteRecord('Statement', recordId);
-                    }
-                }
+                toRemove = existing[key].filter(r => !updatedRecords.includes(r['@rid']));
+                await removeRecords(conn, toRemove);
             }
             counts.success++;
         } catch (err) {
             logger.warn(`${err}`);
             counts.error++;
+            toRemove = existingRecords.filter(
+                record => rawRecord.assertion_id === parseInt(record.sourceId, 10),
+            );
+            await removeRecords(conn, toRemove);
 
             if (err.toString().includes('Cannot read property')) {
                 throw err;

--- a/src/moa/index.js
+++ b/src/moa/index.js
@@ -274,12 +274,12 @@ const loadVariant = async (conn, moaVariant) => {
                 target: 'CategoryVariant',
             });
             return await conn.updateRecord('CategoryVariant', record['@rid'], {
-                displayName: `${signature.name.toUpperCase()} signature present`,
+                displayName: `${signature.name.toUpperCase()} high signature`,
             });
         } catch (err) {
             return conn.addVariant({
                 content: {
-                    displayName: `${signature.name.toUpperCase()} signature present`,
+                    displayName: `${signature.name.toUpperCase()} high signature`,
                     reference1: rid(signature),
                     type: rid(variantType),
                 },

--- a/src/moa/spec.json
+++ b/src/moa/spec.json
@@ -36,10 +36,6 @@
                                             ]
                                         },
                                         "rearrangement_type": {
-                                            "enum": [
-                                                "Translocation",
-                                                "Fusion"
-                                            ],
                                             "type": [
                                                 "string",
                                                 "null"
@@ -56,7 +52,7 @@
                                 {
                                     "properties": {
                                         "alternate_allele": {
-                                            "pattern": "^[ATCG]*$",
+                                            "pattern": "^[ATCG-]*$",
                                             "type": [
                                                 "string",
                                                 "null"
@@ -173,7 +169,7 @@
                                         },
                                         "pathogenic": {
                                             "enum": [
-                                                "1.0",
+                                                "1",
                                                 null
                                             ]
                                         },
@@ -285,15 +281,8 @@
                                 },
                                 {
                                     "properties": {
-                                        "cosmic_signature_number": {
-                                            "pattern": "^\\d+$",
+                                        "cosmic_signature": {
                                             "type": "string"
-                                        },
-                                        "cosmic_signature_version": {
-                                            "enum": [
-                                                "2.0",
-                                                "2"
-                                            ]
                                         },
                                         "feature_type": {
                                             "const": "mutational_signature"
@@ -301,8 +290,7 @@
                                     },
                                     "required": [
                                         "feature_type",
-                                        "cosmic_signature_number",
-                                        "cosmic_signature_version"
+                                        "cosmic_signature"
                                     ],
                                     "type": "object"
                                 },

--- a/test/moa.test.js
+++ b/test/moa.test.js
@@ -77,14 +77,14 @@ describe('parseRelevance', () => {
 
     test('favorable prognosis', () => {
         expect(parseRelevance({
-            favorable_prognosis: true,
+            favorable_prognosis: 1,
             features: [],
         })).toEqual(['favourable prognosis']);
     });
 
     test('unfavorable prognosis', () => {
         expect(parseRelevance({
-            favorable_prognosis: false,
+            favorable_prognosis: 0,
             features: [],
         })).toEqual(['unfavourable prognosis']);
     });


### PR DESCRIPTION
[KBDEV-993](https://www.bcgsc.ca/jira/browse/KBDEV-993)
- favorable_prognosis now using 1/0 instead of true/false
- MOA cosmic_signature now only have name like SBS2, SBS3 instead of number and version
- check/update existing CuratedContent and CategoryVariant before adding a new record
- update spec file to match the current MOA data
- work around for therapy name (Amivantamab-vmjw=>Amivantamab; KU0058684=>olaparib; Tovorafenib=>"pan-raf kinase inhibitor tak-580"), disease name (Any solid tumor=>all solid tumors)
- not checking for existing MOA records due to unmatching assertion_id, instead, removing all MOA records (in datafix) and reload all of them