### PR TITLE
Feature/kbdev 1224 hla alleles signatures 2

### DIFF
--- a/data/signatures.json
+++ b/data/signatures.json
@@ -564,9 +564,6 @@
                 }
             ]
         },
-        "hla genotype": {
-            "description": "homo- or heterozygosity in HLA class I locus (HLA-A, HLA-B or HLA-C)"
-        },
         "homologous recombination deficiency": {
             "description": "genetic instability due to genomic alterations in the homologous recombination (HR) DNA repair pathway",
             "links": [

--- a/data/signatures.json
+++ b/data/signatures.json
@@ -657,10 +657,12 @@
             ]
         },
         "HLA-A*02:01": {
-            "description": "Allele 02:01 for HLA-A gene. Meant to describe all alleles of higher precision, if any; See KBDEV-1224 for more details"
+            "description": "Allele 02:01 for HLA-A gene. Meant to describe all alleles of higher precision, if any; See KBDEV-1224 for more details",
+            "displayName": "HLA-A*02:01"
         },
         "HLA-B*27": {
-            "description": "Allele 27 for HLA-B gene. Meant to describe all alleles of higher precision, if any; See KBDEV-1224 for more details"
+            "description": "Allele 27 for HLA-B gene. Meant to describe all alleles of higher precision, if any; See KBDEV-1224 for more details",
+            "displayName": "HLA-B*27"
         }
     },
     "sources": {


### PR DESCRIPTION
Minor changes to data/signatures.json:
- added displayName for both HLA signatures, so it will be capitalized
- removed 'hla genotype' from the list since it is not used in gkb and is now deprecated 