### PR TITLE
add fetchConditions in OncoTree conn.addRecord()

### DIFF
--- a/src/oncotree/index.js
+++ b/src/oncotree/index.js
@@ -5,7 +5,7 @@
 
 const { request } = require('../util');
 
-const { rid, orderPreferredOntologyTerms } = require('../graphkb');
+const { convertRecordToQueryFilters, orderPreferredOntologyTerms, rid } = require('../graphkb');
 const { logger } = require('../logging');
 const { SOURCE_DEFN: { name: ncitName } } = require('../ncit');
 const { oncotree: SOURCE_DEFN } = require('../sources');
@@ -209,17 +209,26 @@ const upload = async (opt) => {
     const ncitMissingRecords = new Set();
 
     // upload the results
+    logger.info(`Uploading ${records.length} OncoTree Disease records`);
+    let count = 0;
+
     for (const record of records) {
+        count++;
+        logger.info(`${count}/${records.length} - ${record.sourceId}`);
+
         const body = {
-            displayName: `${record.name} [${record.sourceId.toUpperCase()}]`,
-            name: record.name,
+            name: record.name.toLowerCase(),
             source: rid(source),
             sourceId: record.sourceId,
             sourceIdVersion: record.sourceIdVersion,
         };
         const rec = await conn.addRecord({
-            content: body,
+            content: {
+                ...body,
+                displayName: `${record.name} [${record.sourceId.toUpperCase()}]`,
+            },
             existsOk: true,
+            fetchConditions: convertRecordToQueryFilters(body),
             target: 'Disease',
         });
         dbRecordsByCode[record.sourceId] = rec;
@@ -253,7 +262,13 @@ const upload = async (opt) => {
         }
     }
 
+    logger.info('Creating \'subclassOf\' & \'deprecatedBy\' links between records');
+    count = 0;
+
     for (const record of records) {
+        count++;
+        logger.info(`${count}/${records.length} - subclassOf: ${(record.subclassOf || []).length}; deprecatedBy: ${(record.deprecatedBy || []).length}`);
+
         for (const parentRecord of record.subclassOf || []) {
             await conn.addRecord({
                 content: {
@@ -283,6 +298,8 @@ const upload = async (opt) => {
 
     if (ncitMissingRecords.size) {
         logger.warn(`Unable to retrieve ${ncitMissingRecords.size} ncit records for linking`);
+    } else {
+        logger.info(`All ${ncitMissingRecords.size} ncit records has been successfully retreived for linking`);
     }
 };
 

--- a/src/oncotree/index.js
+++ b/src/oncotree/index.js
@@ -226,6 +226,7 @@ const upload = async (opt) => {
             content: {
                 ...body,
                 displayName: `${record.name} [${record.sourceId.toUpperCase()}]`,
+                name: record.name.toLowerCase(),
             },
             existsOk: true,
             fetchConditions: convertRecordToQueryFilters(body),

--- a/src/oncotree/index.js
+++ b/src/oncotree/index.js
@@ -267,7 +267,7 @@ const upload = async (opt) => {
 
     for (const record of records) {
         count++;
-        logger.info(`${count}/${records.length} - subclassOf: ${(record.subclassOf || []).length}; deprecatedBy: ${(record.deprecatedBy || []).length}`);
+        logger.info(`${count}/${records.length} - subclassOf: ${(record.subclassOf || []).length}; deprecates: ${(record.deprecates || []).length}`);
 
         for (const parentRecord of record.subclassOf || []) {
             await conn.addRecord({

--- a/src/oncotree/index.js
+++ b/src/oncotree/index.js
@@ -217,7 +217,6 @@ const upload = async (opt) => {
         logger.info(`${count}/${records.length} - ${record.sourceId}`);
 
         const body = {
-            name: record.name.toLowerCase(),
             source: rid(source),
             sourceId: record.sourceId,
             sourceIdVersion: record.sourceIdVersion,


### PR DESCRIPTION
[KBDEV-1303](https://www.bcgsc.ca/jira/browse/KBDEV-1303) - Update OncoTree terms in production.

Adding explicit displayName in query (from PR [#158](https://github.com/bcgsc/pori_graphkb_loader/pull/158) - [KBDEV-1154](https://www.bcgsc.ca/jira/browse/KBDEV-1154)) is causing uncatched error because of a mismatch between current records and already existing OncoTree records. Solution is to use the fetchConditions arg to discard displayName from comparison.

Also, discarded name from fetchConditions too because 1 record with typo was duplicated from existing record. Current loader state dosen't support updates; versionized records are assumed immutable.

Also, added more detailed logging.