### PR TITLE
Replace 'name' with 'title' in source field of evidenceItems query

### DIFF
--- a/src/civic/evidenceItems.graphql
+++ b/src/civic/evidenceItems.graphql
@@ -70,10 +70,10 @@ query evidenceItems(
       source {
         ascoAbstractId
         citationId
-        name
         publicationYear
         sourceType
         sourceUrl
+        title
       }
       status
       therapies {


### PR DESCRIPTION
Requests to civicdb were failing before this change as of Feb 27, 2026.

I'm unsure if the order of items in the source field matter, but I moved the title field to the bottom of the group.

The evidenceItems example query on the visual editor at https://civicdb.org/api/graphiql  shows only 5 fields though:
source {
        ascoAbstractId
        citationId
        pmcId
        sourceType
        title
}

So some additional look into this change may be required.  But with this change the loader went from having a blank output (which turned out to be an HTTP 400 Bad Request error) to successfully processing records.