### PR TITLE
Snakemake pipeline fixes and downstream data updates from PR #166

### DIFF
--- a/Dockerfile.snakemake
+++ b/Dockerfile.snakemake
@@ -1,0 +1,46 @@
+FROM node:18 AS node_stage
+WORKDIR /usr/src/app
+# Bundle app source
+COPY package*.json ./
+RUN rm -rf node_modules
+RUN npm install
+RUN npm ci --only=production
+# COPY everything not in dockerignore file
+COPY . .
+# set to avoid errors when singularity overloads working dir
+ENV NODE_PATH=/usr/src/app/node_modules
+
+FROM ubuntu:noble
+WORKDIR /usr/src/app
+COPY --from=node_stage /usr/src/app/package*.json ./
+COPY --from=node_stage /usr/src/app/node_modules ./node_modules
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y nodejs python3 python3-pip python3-pulp python3-wheel snakemake unzip wget nano
+
+# Verify Node.js version
+RUN node -v
+
+#RUN pip3 install --upgrade setuptools pip wheel && \
+    #pip3 install "pulp<2.3.1" && \
+    #pip3 install snakemake
+
+RUN mkdir /usr/src/app/snakemake_data
+RUN mkdir /usr/src/app/snakemake_logs
+RUN chmod 777 /usr/src/app/snakemake_data
+RUN chmod 777 /usr/src/app/snakemake_logs
+
+# Copy the Snakefile to the working directory (assuming it's already in the build context)
+COPY . .
+COPY ./download_ensembl_curl_config.txt /usr/src/app/
+COPY ./downloadCosmic.sh /usr/src/app
+
+# Still getting NODE version errors, but a rebuild is quick and helps.
+RUN npm rebuild
+
+# Run the Snakefile using Snakemake
+#CMD [ "sh", "-c", "snakemake --debug -j 1 --config gkb_url=$GKB_URL gkb_user=$GKB_USER gkb_pass=$GKB_PASS --until $GKB_LOADER"]
+CMD [ "sh", "-c", "snakemake --debug -j 1 --config gkb_url=$GKB_URL gkb_user=$GKB_USER gkb_pass=$GKB_PASS"]
+

--- a/Snakefile
+++ b/Snakefile
@@ -1,7 +1,6 @@
 import os
-from textwrap import dedent
 
-CONTAINER = 'docker://bcgsc/pori-graphkb-loader:v6.4.0'
+CONTAINER = 'bcgsc/pori-graphkb-loader'
 DATA_DIR = 'snakemake_data'
 LOGS_DIR = 'snakemake_logs'
 
@@ -10,6 +9,16 @@ if not os.path.exists(DATA_DIR):
 
 if not os.path.exists(LOGS_DIR):
     os.mkdir(LOGS_DIR)
+
+def build_docker_image(tag):
+    docker_image_name = f"pori-graphkb-loader:{tag}"
+    shell(f"docker build -t {docker_image_name} .")
+    return docker_image_name
+
+if config.get('build_docker'):
+    containerchoice = build_docker_image('test')
+else:
+    containerchoice = CONTAINER
 
 
 LOADER_COMMAND = 'node bin/load.js ' + ' '.join([f'--{k} {v}' for k, v in {
@@ -32,10 +41,10 @@ GITHUB_DATA = 'https://raw.githubusercontent.com/bcgsc/pori_graphkb_loader/devel
 rule all:
     input: f'{DATA_DIR}/civic.COMPLETE',
         f'{DATA_DIR}/cgi.COMPLETE',
-        f'{DATA_DIR}/docm.COMPLETE',
-        f'{DATA_DIR}/dgidb.COMPLETE',
-        f'{DATA_DIR}/PMC4468049.COMPLETE',
-        f'{DATA_DIR}/PMC4232638.COMPLETE',
+        #f'{DATA_DIR}/docm.COMPLETE',
+        #f'{DATA_DIR}/dgidb.COMPLETE',
+        #f'{DATA_DIR}/PMC4468049.COMPLETE',
+        #f'{DATA_DIR}/PMC4232638.COMPLETE',
         f'{DATA_DIR}/uberon.COMPLETE',
         f'{DATA_DIR}/fdaApprovals.COMPLETE',
         f'{DATA_DIR}/cancerhotspots.COMPLETE',
@@ -47,165 +56,135 @@ rule all:
 
 rule download_ncit:
     output: f'{DATA_DIR}/ncit/Thesaurus.txt',
-    shell: dedent(f'''\
-        cd {DATA_DIR}/ncit
-        wget https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/Thesaurus.FLAT.zip
-        unzip Thesaurus.FLAT.zip
-        rm Thesaurus.FLAT.zip
-        rm -rf __MACOSX''')
+    shell: f'''
+        mkdir -p {DATA_DIR}/ncit
+        curl https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/Thesaurus.FLAT.zip | zcat > {DATA_DIR}/ncit/Thesaurus.txt
+        rm -rf {DATA_DIR}/ncit/__MACOSX'''
 
 
 rule download_ncit_fda:
     output: f'{DATA_DIR}/ncit/FDA-UNII_NCIt_Subsets.txt'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/ncit
-        wget https://evs.nci.nih.gov/ftp1/FDA/UNII/FDA-UNII_NCIt_Subsets.txt''')
+    shell: f'''
+        curl -L --create-dirs -o {DATA_DIR}/ncit/FDA-UNII_NCIt_Subsets.txt https://evs.nci.nih.gov/ftp1/FDA/UNII/FDA-UNII_NCIt_Subsets.txt'''
 
 
 rule download_ensembl:
+    # This is the original query string.  This has been URL encoded and put into download_ensembl_curl_config.txt
+    # Curl then runs using that config file to download ensembl.
+    #query_string='<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query><Query  virtualSchemaName = "default" formatter = "TSV" header = "1" uniqueRows = "0" count = "" datasetConfigVersion = "0.6" ><Dataset name = "hsapiens_gene_ensembl" interface = "default" ><Filter name = "transcript_biotype" value = "protein_coding"/><Attribute name = "ensembl_gene_id" /><Attribute name = "ensembl_gene_id_version" /><Attribute name = "ensembl_transcript_id" /><Attribute name = "ensembl_transcript_id_version" /><Attribute name = "ensembl_peptide_id" /><Attribute name = "ensembl_peptide_id_version" /><Attribute name = "hgnc_id" /><Attribute name = "refseq_mrna" /><Attribute name = "description" /><Attribute name = "external_gene_name" /><Attribute name = "external_gene_source" /></Dataset></Query>'
     output: f'{DATA_DIR}/ensembl/biomart_export.tsv'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/ensembl
-        query_string='<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query><Query  virtualSchemaName = "default" formatter = "TSV" header = "1" uniqueRows = "0" count = "" datasetConfigVersion = "0.6" ><Dataset name = "hsapiens_gene_ensembl" interface = "default" ><Filter name = "transcript_biotype" value = "protein_coding"/><Attribute name = "ensembl_gene_id" /><Attribute name = "ensembl_gene_id_version" /><Attribute name = "ensembl_transcript_id" /><Attribute name = "ensembl_transcript_id_version" /><Attribute name = "ensembl_peptide_id" /><Attribute name = "ensembl_peptide_id_version" /><Attribute name = "hgnc_id" /><Attribute name = "refseq_mrna" /><Attribute name = "description" /><Attribute name = "external_gene_name" /><Attribute name = "external_gene_source" /></Dataset></Query>'
-        wget -O biomart_export.tsv "http://www.ensembl.org/biomart/martservice?query=$query_string"
-        ''')
+    shell: f'''
+        curl --config download_ensembl_curl_config.txt 2>&1 | tee -a downloadEnsemblLog.txt
+        '''
 
 
 rule download_fda_srs:
     output: f'{DATA_DIR}/fda/UNII_Records.txt'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/fda
-        wget https://precision.fda.gov/uniisearch/archive/latest/UNII_Data.zip
-        unzip UNII_Data.zip
-        rm UNII_Data.zip
-
-        mv UNII*.txt UNII_Records.txt
-        ''')
+    shell: f'''
+        curl -L --create-dirs -o {DATA_DIR}/fda/UNII_Data.zip https://precision.fda.gov/uniisearch/archive/latest/UNII_Data.zip
+        unzip -o -d {DATA_DIR}/fda {DATA_DIR}/fda/UNII_Data.zip
+        rm {DATA_DIR}/fda/UNII_Data.zip
+        mv {DATA_DIR}/fda/UNII*.txt {DATA_DIR}/fda/UNII_Records.txt
+        '''
 
 
 rule download_refseq:
     output: f'{DATA_DIR}/refseq/LRG_RefSeqGene.tab'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/refseq
-        wget -O LRG_RefSeqGene.tab ftp://ftp.ncbi.nih.gov/refseq/H_sapiens/RefSeqGene/LRG_RefSeqGene
-        ''')
+    shell: f'''
+        curl -A "Mozilla" --fail-with-body -L --create-dirs -o {DATA_DIR}/refseq/LRG_RefSeqGene.tab ftp://ftp.ncbi.nih.gov/refseq/H_sapiens/RefSeqGene/LRG_RefSeqGene
+        '''
 
 
 rule download_uberon:
     output: f'{DATA_DIR}/uberon/uberon.owl'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/uberon
-        wget http://purl.obolibrary.org/obo/uberon.owl
-        ''')
+    shell: f'''
+        curl -A "Mozilla" -L --create-dirs -o {DATA_DIR}/uberon/uberon.owl https://github.com/obophenotype/uberon/releases/latest/download/uberon.owl
+        '''
 
 
 rule download_do:
     output: f'{DATA_DIR}/do/doid.json'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/do;
-        REPO=https://github.com/DiseaseOntology/HumanDiseaseOntology.git;
-        LATEST=$(git ls-remote $REPO --tags v\\* | cut -f 2 | sed 's/refs\\/tags\///' | grep '\\bv[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\\b' | sort -d | tail -n 1)
-        echo $LATEST
-        wget https://github.com/DiseaseOntology/HumanDiseaseOntology/raw/$LATEST/src/ontology/doid.json
-        ''')
+    shell: f'''
+        curl -A "Mozilla" --create-dirs -o {DATA_DIR}/do/doid.json https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/refs/heads/main/src/ontology/doid.json
+        '''
+
 
 
 rule download_drugbank:
     output: f'{DATA_DIR}/drugbank/full_database.xml'
-    shell: dedent(f'''\
+    shell: f'''
         cd {DATA_DIR}/drugbank
         wget https://www.drugbank.ca/releases
         latest=$(grep 'href="/releases/[^"]*"' -o releases | cut -f 3 -d/ | sed 's/"//' | sort -V | tail -n 2 | head -n 1)
         rm releases
         filename="drugbank_all_full_database_v$latest".xml
 
-        curl -Lfv -o ${{filename}}.zip -u {DRUGBANK_EMAIL}:{DRUGBANK_PASSWORD} https://go.drugbank.com/releases/5-1-8/downloads/all-full-database
+        curl -L -v --fail-with-body -o ${{filename}}.zip -u {DRUGBANK_EMAIL}:{DRUGBANK_PASSWORD} https://go.drugbank.com/releases/5-1-8/downloads/all-full-database
         unzip ${{filename}}.zip
-        mv full\ database.xml full_database.xml''')
-
+        mv full\ database.xml full_database.xml'''
 
 rule download_PMC4468049:
     output: f'{DATA_DIR}/PMC4468049/NIHMS632238-supplement-2.xlsx'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/PMC4468049
-        wget https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4468049/bin/NIHMS632238-supplement-2.xlsx
-        ''')
+    shell: f''' curl -A "Mozilla" --create-dirs -o {DATA_DIR}/PMC4468049/NIHMS632238-supplement-2.xlsx https://pmc.ncbi.nlm.nih.gov/articles/instance/4468049/bin/NIHMS632238-supplement-2.xlsx'''
 
 
 rule download_PMC4232638:
     output: f'{DATA_DIR}/PMC4232638/13059_2014_484_MOESM2_ESM.xlsx'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/PMC4232638
-        wget https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4232638/bin/13059_2014_484_MOESM2_ESM.xlsx
-        ''')
-
+    shell: f''' curl -A "Mozilla" --create-dirs -o {DATA_DIR}/PMC4232638/13059_2014_484_MOESM2_ESM.xlsx https://pmc.ncbi.nlm.nih.gov/articles/instance/4232638/bin/13059_2014_484_MOESM2_ESM.xlsx'''
 
 rule download_cgi:
     output: f'{DATA_DIR}/cgi/cgi_biomarkers_per_variant.tsv'
-    shell: dedent(f'''\
-        cd {DATA_DIR}/cgi
-        wget https://www.cancergenomeinterpreter.org/data/biomarkers/cgi_biomarkers_20180117.zip
-        unzip cgi_biomarkers_20180117.zip
-        ''')
+    shell: f'''
+        curl --create-dirs -o {DATA_DIR}/cgi/cgi_biomarkers_per_variant.tsv https://www.cancergenomeinterpreter.org/2021/data/biomarkers/cgi_biomarkers_latest.tsv
+        '''
 
 
 rule download_local_data:
     output: f'{DATA_DIR}/local/{{local}}.json'
-    shell: dedent(f'''\
+    shell: f'''
+        mkdir -p {DATA_DIR}/local
         cd {DATA_DIR}/local
         wget {GITHUB_DATA}/{{wildcards.local}}.json
-        ''')
+        '''
 
 
 rule download_cancerhotspots:
     output: f'{DATA_DIR}/cancerhotspots/cancerhotspots.v2.maf'
-    shell: dedent(f'''\
-        mkdir -p {DATA_DIR}/cancerhotspots
-        cd {DATA_DIR}/cancerhotspots
-        wget https://cbioportal-download.s3.amazonaws.com/cancerhotspots.v2.maf.gz
-        gunzip cancerhotspots.v2.maf.gz
-        ''')
+    shell: f'''
+        curl -A "Mozilla" --create-dirs -o {DATA_DIR}/cancerhotspots/cancerhotspots.v2.maf.gz https://cbioportal-download.s3.amazonaws.com/cancerhotspots.v2.maf.gz
+        gunzip {DATA_DIR}/cancerhotspots/cancerhotspots.v2.maf.gz
+        '''
 
 
 
 rule download_cosmic_resistance:
     output: f'{DATA_DIR}/cosmic/CosmicResistanceMutations.tsv'
-    shell: dedent(f'''
-        cd {DATA_DIR}/cosmic
-        AUTH=$( echo "{COSMIC_EMAIL}:{COSMIC_PASSWORD}" | base64 )
-        resp=$( curl -H "Authorization: Basic $AUTH" https://cancer.sanger.ac.uk/cosmic/file_download/GRCh38/cosmic/v92/CosmicResistanceMutations.tsv.gz );
-        url=$( node  -e "var resp = $resp; console.log(resp.url);" );
-        curl "$url" -o CosmicResistanceMutations.tsv.gz
-        gunzip CosmicResistanceMutations.tsv.gz
-        ''')
+    shell: f'''
+        ./downloadCosmic.sh mutations {COSMIC_EMAIL} {COSMIC_PASSWORD} "https://cancer.sanger.ac.uk/api/mono/products/v1/downloads/scripted?path=grch38/cosmic/v101/Cosmic_ResistanceMutations_Tsv_v101_GRCh38.tar&bucket=downloads" {DATA_DIR}
+        mv {DATA_DIR}/cosmic/mutations/Cosmic_ResistanceMutations_v[0-9]*_GRCh38.tsv {DATA_DIR}/cosmic/CosmicResistanceMutations.tsv
+        '''
 
 
 rule download_cosmic_diseases:
     output: f'{DATA_DIR}/cosmic/classification.csv'
-    shell: dedent(f'''
-        cd {DATA_DIR}/cosmic
-        AUTH=$( echo "{COSMIC_EMAIL}:{COSMIC_PASSWORD}" | base64 )
-        resp=$( curl -H "Authorization: Basic $AUTH" https://cancer.sanger.ac.uk/cosmic/file_download/GRCh38/cosmic/v92/classification.csv );
-        url=$( node  -e "var resp = $resp; console.log(resp.url);" );
-        curl "$url" -o classification.csv
-        ''')
+    shell: f'''
+        ./downloadCosmic.sh diseases {COSMIC_EMAIL} {COSMIC_PASSWORD} "https://cancer.sanger.ac.uk/api/mono/products/v1/downloads/scripted?path=grch38/cosmic/v101/Cosmic_Classification_Tsv_v101_GRCh38.tar&bucket=downloads" {DATA_DIR}
+        mv {DATA_DIR}/cosmic/diseases/Cosmic_Classification_v[0-9]*_GRCh38.tsv {DATA_DIR}/cosmic/diseases/classification.tsv
+        tr ',' '\\t' < {DATA_DIR}/cosmic/diseases/classification.tsv > {DATA_DIR}/cosmic/classification.csv
+        '''
 
 
 rule download_cosmic_fusions:
     output: f'{DATA_DIR}/cosmic/CosmicFusionExport.tsv'
-    shell: dedent(f'''
-        cd {DATA_DIR}/cosmic
-        AUTH=$( echo "{COSMIC_EMAIL}:{COSMIC_PASSWORD}" | base64 )
-        resp=$( curl -H "Authorization: Basic $AUTH" https://cancer.sanger.ac.uk/cosmic/file_download/GRCh38/cosmic/v92/CosmicFusionExport.tsv.gz );
-        url=$( node  -e "var resp = $resp; console.log(resp.url);" );
-        curl "$url" -o CosmicFusionExport.tsv.gz
-        gunzip CosmicFusionExport.tsv.gz
-        ''')
+    shell: f'''
+        ./downloadCosmic.sh fusion {COSMIC_EMAIL} {COSMIC_PASSWORD} "https://cancer.sanger.ac.uk/api/mono/products/v1/downloads/scripted?path=grch38/cosmic/v101/Cosmic_Fusion_Tsv_v101_GRCh38.tar&bucket=downloads" {DATA_DIR}
+        mv {DATA_DIR}/cosmic/fusion/Cosmic_Fusion_v[0-9]*_GRCh38.tsv {DATA_DIR}/cosmic/CosmicFusionExport.tsv
+        '''
 
 
 rule load_local:
     input: f'{DATA_DIR}/local/{{local}}.json'
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/local-{{local}}.logs.txt'
     output: f'{DATA_DIR}/local-{{local}}.COMPLETE'
     shell: LOADER_COMMAND + ' file ontology {input} &> {log}; cp {log} {output}'
@@ -214,7 +193,7 @@ rule load_local:
 rule load_ncit:
     input: expand(rules.load_local.output, local=['vocab']),
         data=rules.download_ncit.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/ncit.logs.txt'
     output: f'{DATA_DIR}/ncit.COMPLETE'
     shell: LOADER_COMMAND + ' file ncit {input.data} &> {log}; cp {log} {output}'
@@ -224,7 +203,7 @@ rule load_fda_srs:
     input: expand(rules.load_local.output, local=['vocab']),
         f'{DATA_DIR}/ncit.COMPLETE',
         data=f'{DATA_DIR}/fda/UNII_Records.txt'
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/fdaSrs.logs.txt'
     output: f'{DATA_DIR}/fdaSrs.COMPLETE'
     shell: LOADER_COMMAND + ' file fdaSrs {input.data} &> {log}; cp {log} {output}'
@@ -234,7 +213,7 @@ rule load_ncit_fda:
     input: rules.load_ncit.output,
         rules.load_fda_srs.output,
         data=rules.download_ncit_fda.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/ncitFdaXref.logs.txt'
     output: f'{DATA_DIR}/ncitFdaXref.COMPLETE'
     shell: LOADER_COMMAND + ' file ncitFdaXref {input.data} &> {log}; cp {log} {output}'
@@ -243,7 +222,7 @@ rule load_ncit_fda:
 rule load_refseq:
     input: expand(rules.load_local.output, local=['vocab']),
         data=rules.download_refseq.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/refseq.logs.txt'
     output: f'{DATA_DIR}/refseq.COMPLETE'
     shell: LOADER_COMMAND + ' file refseq {input.data} &> {log}; cp {log} {output}'
@@ -252,7 +231,7 @@ rule load_refseq:
 rule load_ensembl:
     input: rules.load_refseq.output,
         data=rules.download_ensembl.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/ensembl.logs.txt'
     output: f'{DATA_DIR}/ensembl.COMPLETE'
     shell: LOADER_COMMAND + ' file ensembl {input.data} &> {log}; cp {log} {output}'
@@ -261,7 +240,7 @@ rule load_ensembl:
 rule load_do:
     input: rules.load_ncit.output,
         data=rules.download_do.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/do.logs.txt'
     output: f'{DATA_DIR}/do.COMPLETE'
     shell: LOADER_COMMAND + ' file diseaseOntology {input.data} &> {log}; cp {log} {output}'
@@ -270,7 +249,7 @@ rule load_do:
 rule load_uberon:
     input: rules.load_ncit.output,
         data=rules.download_uberon.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/uberon.logs.txt'
     output: f'{DATA_DIR}/uberon.COMPLETE'
     shell: LOADER_COMMAND + ' file uberon {input.data} &> {log}; cp {log} {output}'
@@ -279,7 +258,7 @@ rule load_uberon:
 rule load_drugbank:
     input: rules.load_fda_srs.output,
         data=rules.download_drugbank.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/drugbank.logs.txt'
     output: f'{DATA_DIR}/drugbank.COMPLETE'
     shell: LOADER_COMMAND + ' file drugbank {input.data} &> {log}; cp {log} {output}'
@@ -287,7 +266,7 @@ rule load_drugbank:
 
 rule load_oncotree:
     input: rules.load_ncit.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/oncotree.logs.txt'
     output: f'{DATA_DIR}/oncotree.COMPLETE'
     shell: LOADER_COMMAND + ' api oncotree &> {log}; cp {log} {output}'
@@ -296,7 +275,7 @@ rule load_oncotree:
 def get_drug_inputs(wildcards):
     inputs = [*rules.load_ncit.output]
     inputs.extend(rules.load_fda_srs.output)
-    container: CONTAINER
+    containerized: containerchoice
     if USE_DRUGBANK:
         inputs.append(*rules.load_drugbank.output)
     return inputs
@@ -304,7 +283,7 @@ def get_drug_inputs(wildcards):
 
 rule all_drugs:
     input: lambda wildcards: get_drug_inputs(wildcards)
-    container: CONTAINER
+    containerized: containerchoice
     output: f'{DATA_DIR}/all_drugs.COMPLETE'
     shell: 'touch {output}'
 
@@ -313,14 +292,14 @@ rule all_diseases:
     input: rules.load_do.output,
         rules.load_ncit.output,
         rules.load_oncotree.output
-    container: CONTAINER
+    containerized: containerchoice
     output: f'{DATA_DIR}/all_diseases.COMPLETE'
     shell: 'touch {output}'
 
 
 rule all_local:
     input: expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes', 'evidenceLevels', 'aacr', 'asco']),
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/all_local.logs.txt'
     output: f'{DATA_DIR}/all_local.COMPLETE'
     shell: 'touch {output}'
@@ -328,7 +307,7 @@ rule all_local:
 
 rule load_dgidb:
     input: rules.all_local.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/dgidb.logs.txt'
     output: f'{DATA_DIR}/dgidb.COMPLETE'
     shell: LOADER_COMMAND + ' api dgidb &> {log}; cp {log} {output}'
@@ -339,7 +318,7 @@ rule load_cancerhotspots:
         rules.load_oncotree.output,
         rules.load_ensembl.output,
         data=rules.download_cancerhotspots.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/cancerhotspots.logs.txt'
     output: f'{DATA_DIR}/cancerhotspots.COMPLETE'
     shell: LOADER_COMMAND + ' file cancerhotspots {input.data} &> {log}; cp {log} {output}'
@@ -348,7 +327,7 @@ rule load_cancerhotspots:
 rule load_PMC4232638:
     input: expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes']),
         data=rules.download_PMC4232638.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/PMC4232638.logs.txt'
     output: f'{DATA_DIR}/PMC4232638.COMPLETE'
     shell: LOADER_COMMAND + ' file PMC4232638 {input.data} &> {log}; cp {log} {output}'
@@ -358,7 +337,7 @@ rule load_PMC4468049:
     input: expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes']),
         rules.all_diseases.output,
         data=rules.download_PMC4468049.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/PMC4468049.logs.txt'
     output: f'{DATA_DIR}/PMC4468049.COMPLETE'
     shell: LOADER_COMMAND + ' file PMC4468049 {input.data} &> {log}; cp {log} {output}'
@@ -368,7 +347,7 @@ rule load_civic:
     input: expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes', 'evidenceLevels', 'aacr', 'asco']),
         rules.load_ncit.output,
         rules.load_do.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/civic.logs.txt'
     output: f'{DATA_DIR}/civic.COMPLETE'
     shell: LOADER_COMMAND + ' civic &> {log}; cp {log} {output}'
@@ -379,25 +358,25 @@ rule load_cgi:
         rules.all_diseases.output,
         rules.all_drugs.output,
         data=rules.download_cgi.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/cgi.logs.txt'
     output: f'{DATA_DIR}/cgi.COMPLETE'
     shell: LOADER_COMMAND + ' file cgi {input.data} &> {log}; cp {log} {output}'
 
-
-rule load_docm:
-    input: expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes']),
-        rules.load_ncit.output,
-        rules.load_do.output
-    container: CONTAINER
-    log: f'{LOGS_DIR}/docm.logs.txt'
-    output: f'{DATA_DIR}/docm.COMPLETE'
-    shell: LOADER_COMMAND + ' api docm &> {log}; cp {log} {output}'
+# DOCM has been retired and superceded by the CIViC project
+#rule load_docm:
+#    input: expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes']),
+#        rules.load_ncit.output,
+#        rules.load_do.output
+#    containerized: containerchoice
+#    log: f'{LOGS_DIR}/docm.logs.txt'
+#    output: f'{DATA_DIR}/docm.COMPLETE'
+#    shell: LOADER_COMMAND + ' api docm &> {log}; cp {log} {output}'
 
 
 rule load_approvals:
     input:
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/fdaApprovals.logs.txt'
     output: f'{DATA_DIR}/fdaApprovals.COMPLETE'
     shell: LOADER_COMMAND + ' api fdaApprovals &> {log}; cp {log} {output}'
@@ -407,7 +386,7 @@ rule load_clinicaltrialsgov:
     input: expand(rules.load_local.output, local=['vocab']),
         rules.all_diseases.output,
         rules.all_drugs.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/clinicaltrialsgov.logs.txt'
     output: f'{DATA_DIR}/clinicaltrialsgov.COMPLETE'
     shell: LOADER_COMMAND + ' clinicaltrialsgov &> {log}; cp {log} {output}'
@@ -419,7 +398,7 @@ rule load_cosmic_resistance:
         rules.all_drugs.output,
         main=rules.download_cosmic_resistance.output,
         supp=rules.download_cosmic_diseases.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/cosmic_resistance.logs.txt'
     output: f'{DATA_DIR}/cosmic_resistance.COMPLETE'
     shell: LOADER_COMMAND + ' cosmic resistance {input.main} {input.supp} &> {log}; cp {log} {output}'
@@ -429,7 +408,7 @@ rule load_cosmic_fusions:
     input: rules.all_diseases.output,
         main=rules.download_cosmic_fusions.output,
         supp=rules.download_cosmic_diseases.output
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/cosmic_fusions.logs.txt'
     output: f'{DATA_DIR}/cosmic_fusions.COMPLETE'
     shell: LOADER_COMMAND + ' cosmic fusions {input.main} {input.supp} &> {log}; cp {log} {output}'
@@ -438,7 +417,7 @@ rule load_cosmic_fusions:
 rule load_moa:
     input: rules.load_oncotree.output,
         expand(rules.load_local.output, local=['vocab', 'signatures', 'chromosomes', 'evidenceLevels', 'aacr', 'asco'])
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/load_moa.logs.txt'
     output: f'{DATA_DIR}/moa.COMPLETE'
     shell: LOADER_COMMAND + ' api moa  &> {log}; cp {log} {output}'
@@ -447,14 +426,14 @@ rule load_moa:
 # input isn't actually needed but it is a file-type loader, so a dummy file must be supplied
 rule download_sources:
     output: f'{DATA_DIR}/local/sources.json'
-    shell: dedent(f'''\
+    shell: f'''
         cd {DATA_DIR}/local
         touch sources.json
-        ''')
+        '''
 
 rule load_sources:
     input: f'{DATA_DIR}/local/sources.json'
-    container: CONTAINER
+    containerized: containerchoice
     log: f'{LOGS_DIR}/sources.logs.txt'
     output: f'{DATA_DIR}/sources.COMPLETE'
     shell: LOADER_COMMAND + ' file sources {input} &> {log}; cp {log} {output}'
@@ -473,6 +452,6 @@ rule all_ontologies:
         rules.load_fda_srs.output,
         rules.load_ncit_fda.output,
         rules.load_dgidb.output
-    container: CONTAINER
+    containerized: containerchoice
     output: f'{DATA_DIR}/all_ontologies.COMPLETE'
     shell: 'touch {output}'

--- a/downloadCosmic.sh
+++ b/downloadCosmic.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+AUTH=$( echo "$2:$3" | base64 )
+RESP=$( curl -H "Authorization: Basic $AUTH" "$4" )
+# If you are getting a blank $RESP, make sure to log in to the COSMIC website and accept the terms of use.
+URL=$( node  -e "var resp = $RESP; console.log(resp.url);" )
+curl --create-dirs "$URL" -o $5/cosmic/$1/Cosmic.tar
+tar -xvf $5/cosmic/$1/Cosmic.tar -C $5/cosmic/$1/
+gunzip -f $5/cosmic/$1/*.tsv.gz # should only have one 

--- a/download_ensembl_curl_config.txt
+++ b/download_ensembl_curl_config.txt
@@ -1,0 +1,7 @@
+--location
+--fail-with-body 
+--create-dirs
+-o snakemake_data/ensembl/biomart_export.tsv
+-v
+-A "Mozilla"
+url="https://may2025.archive.ensembl.org/biomart/martservice?query=%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%3C%21DOCTYPE%20Query%3E%3CQuery%20%20virtualSchemaName%20%3D%20%22default%22%20formatter%20%3D%20%22TSV%22%20header%20%3D%20%221%22%20uniqueRows%20%3D%20%220%22%20count%20%3D%20%22%22%20datasetConfigVersion%20%3D%20%220.6%22%20%3E%3CDataset%20name%20%3D%20%22hsapiens_gene_ensembl%22%20interface%20%3D%20%22default%22%20%3E%3CFilter%20name%20%3D%20%22transcript_biotype%22%20value%20%3D%20%22protein_coding%22%2F%3E%3CAttribute%20name%20%3D%20%22ensembl_gene_id%22%20%2F%3E%3CAttribute%20name%20%3D%20%22ensembl_gene_id_version%22%20%2F%3E%3CAttribute%20name%20%3D%20%22ensembl_transcript_id%22%20%2F%3E%3CAttribute%20name%20%3D%20%22ensembl_transcript_id_version%22%20%2F%3E%3CAttribute%20name%20%3D%20%22ensembl_peptide_id%22%20%2F%3E%3CAttribute%20name%20%3D%20%22ensembl_peptide_id_version%22%20%2F%3E%3CAttribute%20name%20%3D%20%22hgnc_id%22%20%2F%3E%3CAttribute%20name%20%3D%20%22refseq_mrna%22%20%2F%3E%3CAttribute%20name%20%3D%20%22description%22%20%2F%3E%3CAttribute%20name%20%3D%20%22external_gene_name%22%20%2F%3E%3CAttribute%20name%20%3D%20%22external_gene_source%22%20%2F%3E%3C%2FDataset%3E%3C%2FQuery%3E"

--- a/src/fdaSrs/index.js
+++ b/src/fdaSrs/index.js
@@ -9,7 +9,7 @@ const { fdaSrs: SOURCE_DEFN } = require('../sources');
 
 const HEADER = {
     id: 'UNII',
-    name: 'PT',
+    name: 'Display Name',
     ncit: 'NCIT',
     pubchem: 'PUBCHEM',
 };


### PR DESCRIPTION
- Replace dedent/cd/wget pattern with curl --create-dirs throughout Snakefile to fix silent failures where shell sections would exit without running commands
- Update Ensembl download to use may2025.archive.ensembl.org (main site broken) and move query string to download_ensembl_curl_config.txt
- Update CGI biomarkers download URL (changed upstream, no longer zipped)
- Add Dockerfile.snakemake: multi-stage build with npm rebuild to fix Node version compilation issues with native deps (node-expat/xml-stream)
- Add downloadCosmic.sh helper script for COSMIC download auth flow
- Fix fdaSrs/index.js: UNII file header renamed 'PT' -> 'Display Name' upstream, causing all 168k records to be skipped silently